### PR TITLE
Fix NX project names for docker deploy check

### DIFF
--- a/.github/workflows/continuous_integration_checks.yml
+++ b/.github/workflows/continuous_integration_checks.yml
@@ -211,7 +211,7 @@ jobs:
     env:
       NX_BASE: ${{ needs.analyze.outputs.base }}
       NX_HEAD: ${{ needs.analyze.outputs.head }}
-      NX_PROJECT_NAME: 'api-emby-data-check'
+      NX_PROJECT_NAME: 'emby-data-check-api'
       DOCKERFILE: './docker/Dockerfile.prod.api-edc'
       READMEFILE: './docs/docker/docker.api.md'
 
@@ -255,7 +255,7 @@ jobs:
     env:
       NX_BASE: ${{ needs.analyze.outputs.base }}
       NX_HEAD: ${{ needs.analyze.outputs.head }}
-      NX_PROJECT_NAME: 'angular-emby-data-check'
+      NX_PROJECT_NAME: 'emby-data-check-angular-material'
       DOCKERFILE: './docker/Dockerfile.prod.angular-edc'
       READMEFILE: './docs/docker/docker.ui.md'
 


### PR DESCRIPTION
As the Nx project names have been changed after the restart, these changes should also be done in the CI/CD workflow file. This enables the workflow to detect changes triggering the build of a now docker image.