### PR TITLE
Refactor swagger endpoint; repair docker build

### DIFF
--- a/.github/workflows/continuous_integration_checks.yml
+++ b/.github/workflows/continuous_integration_checks.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/wf-ctx-value
 
       - name: 'Print context VARS'
-        run: echo ${{ vars }}
+        run: echo "${{ vars.DOCKERHUB_REPOSITORY_API }}"
 
   build:
     name: Build

--- a/.github/workflows/continuous_integration_checks.yml
+++ b/.github/workflows/continuous_integration_checks.yml
@@ -36,9 +36,6 @@ jobs:
         id: wf-ctx-value
         uses: ./.github/actions/wf-ctx-value
 
-      - name: 'Print context VARS'
-        run: echo "${{ vars.DOCKERHUB_REPOSITORY_API }}"
-
   build:
     name: Build
 

--- a/.github/workflows/continuous_integration_checks.yml
+++ b/.github/workflows/continuous_integration_checks.yml
@@ -36,6 +36,9 @@ jobs:
         id: wf-ctx-value
         uses: ./.github/actions/wf-ctx-value
 
+      - name: 'Print context VARS'
+        run: echo ${{ vars }}
+
   build:
     name: Build
 
@@ -237,7 +240,7 @@ jobs:
         with:
           docker-file: ${{ env.DOCKERFILE }}
           docker-hub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          docker-hub-repository: ${{ secrets.DOCKERHUB_REPOSITORY_API }}
+          docker-hub-repository: ${{ vars.DOCKERHUB_REPOSITORY_API }}
           docker-hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           need-new-image: ${{ steps.detectedChanges.outputs.need-new-image }}
           need-sync-readme: ${{ steps.detectedChanges.outputs.need-sync-readme }}
@@ -281,7 +284,7 @@ jobs:
         with:
           docker-file: ${{ env.DOCKERFILE }}
           docker-hub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          docker-hub-repository: ${{ secrets.DOCKERHUB_REPOSITORY_UI }}
+          docker-hub-repository: ${{ vars.DOCKERHUB_REPOSITORY_UI }}
           docker-hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           need-new-image: ${{ steps.detectedChanges.outputs.need-new-image }}
           need-sync-readme: ${{ steps.detectedChanges.outputs.need-sync-readme }}

--- a/apps/emby-data-check-api/src/main.ts
+++ b/apps/emby-data-check-api/src/main.ts
@@ -31,7 +31,7 @@ async function bootstrap() {
     customSiteTitle: 'Emby Data Check - API Docs',
   };
   const document = SwaggerModule.createDocument(app, config, options);
-  SwaggerModule.setup('api', app, document, customOptions);
+  SwaggerModule.setup('swagger', app, document, customOptions);
 
   await app.listen(port);
   Logger.log(`🚀 Application is running on: http://localhost:${port}/${globalPrefix}`);


### PR DESCRIPTION
* The Swagger API documentation can be opened by `http(s)://<hostname>/swagger` from now on.
* The docker build step was using the wrong environment variables. It should use the VARS context now instead of the secrets context for the repository names in docker hub.