### PR TITLE
Fix Docker build

### DIFF
--- a/docker/Dockerfile.prod.angular-edc
+++ b/docker/Dockerfile.prod.angular-edc
@@ -6,7 +6,6 @@ WORKDIR /home/node
 # Use Docker's layer concepts while copying some required files
 # tsconfig.json: How to transpile TS code to JavaScript
 COPY --chown=node:node tsconfig.base.json .
-COPY --chown=node:node angular.json .
 COPY --chown=node:node .nvmrc .
 
 # package*.json files to install dependencies

--- a/docker/Dockerfile.prod.api-edc
+++ b/docker/Dockerfile.prod.api-edc
@@ -13,7 +13,6 @@ WORKDIR /home/node
 # Use Docker's layer concepts while copying some required files
 # tsconfig.json: How to transpile TS code to JavaScript
 COPY --chown=node:node tsconfig.base.json .
-COPY --chown=node:node angular.json .
 COPY --chown=node:node .nvmrc .
 
 # package*.json files to install dependencies


### PR DESCRIPTION
The Nx workspaces don't create a file `angular.json` anymore. This is  blocking the docker build process currently. With this PR, the corresponding COPY statements are removed.