### PR TITLE
Inject dependencies in test classes

### DIFF
--- a/apps/emby-data-check-api/src/app/emby-user/controller/emby-user.controller.spec.ts
+++ b/apps/emby-data-check-api/src/app/emby-user/controller/emby-user.controller.spec.ts
@@ -1,13 +1,32 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ServerDbService } from '../../server/service/server-db.service';
+import { UserDbService } from '../../user/service/user-db.service';
+import { EmbyUserDbService } from '../service/emby-user-db.service';
+import { EmbyUserHttpService } from '../service/emby-user-http.service';
 import { EmbyUserController } from './emby-user.controller';
 
 describe('EmbyUserController', () => {
   let controller: EmbyUserController;
 
+  const mockEmbyUserDbService = {};
+  const mockEmbyUserHttpService = {};
+  const mockUserDbService = {};
+  const mockServerDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EmbyUserController],
-    }).compile();
+      providers: [EmbyUserDbService, EmbyUserHttpService, UserDbService, ServerDbService],
+    })
+      .overrideProvider(EmbyUserDbService)
+      .useValue(mockEmbyUserDbService)
+      .overrideProvider(EmbyUserHttpService)
+      .useValue(mockEmbyUserHttpService)
+      .overrideProvider(UserDbService)
+      .useValue(mockUserDbService)
+      .overrideProvider(ServerDbService)
+      .useValue(mockServerDbService)
+      .compile();
 
     controller = module.get<EmbyUserController>(EmbyUserController);
   });

--- a/apps/emby-data-check-api/src/app/emby-user/service/emby-user-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/emby-user/service/emby-user-db.service.spec.ts
@@ -4,10 +4,15 @@ import { EmbyUserDbService } from './emby-user-db.service';
 describe('EmbyUserDbService', () => {
   let service: EmbyUserDbService;
 
+  const mockEmbyUserDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [EmbyUserDbService],
-    }).compile();
+    })
+      .overrideProvider(EmbyUserDbService)
+      .useValue(mockEmbyUserDbService)
+      .compile();
 
     service = module.get<EmbyUserDbService>(EmbyUserDbService);
   });

--- a/apps/emby-data-check-api/src/app/emby-user/service/emby-user-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/emby-user/service/emby-user-db.service.spec.ts
@@ -1,18 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EmbyUserEntity } from '../models/emby-user.entity';
 import { EmbyUserDbService } from './emby-user-db.service';
 
 describe('EmbyUserDbService', () => {
   let service: EmbyUserDbService;
 
-  const mockEmbyUserDbService = {};
+  const mockEmbyUserEntityRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [EmbyUserDbService],
-    })
-      .overrideProvider(EmbyUserDbService)
-      .useValue(mockEmbyUserDbService)
-      .compile();
+      providers: [EmbyUserDbService, { provide: getRepositoryToken(EmbyUserEntity), useValue: mockEmbyUserEntityRepository }],
+    }).compile();
 
     service = module.get<EmbyUserDbService>(EmbyUserDbService);
   });

--- a/apps/emby-data-check-api/src/app/emby-user/service/emby-user-http.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/emby-user/service/emby-user-http.service.spec.ts
@@ -4,10 +4,15 @@ import { EmbyUserHttpService } from './emby-user-http.service';
 describe('EmbyUserHttpService', () => {
   let service: EmbyUserHttpService;
 
+  const mockEmbyUserHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [EmbyUserHttpService],
-    }).compile();
+    })
+      .overrideProvider(EmbyUserHttpService)
+      .useValue(mockEmbyUserHttpService)
+      .compile();
 
     service = module.get<EmbyUserHttpService>(EmbyUserHttpService);
   });

--- a/apps/emby-data-check-api/src/app/installation/controller/installation.controller.spec.ts
+++ b/apps/emby-data-check-api/src/app/installation/controller/installation.controller.spec.ts
@@ -1,13 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ServerDbService } from '../../server/service/server-db.service';
+import { InstallationDbService } from '../service/installation-db.service';
+import { InstallationHttpService } from '../service/installation-http.service';
 import { InstallationController } from './installation.controller';
 
 describe('InstallationController', () => {
   let controller: InstallationController;
 
+  const mockInstallationDbService = {};
+  const mockInstallationHttpService = {};
+  const mockServerDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [InstallationController],
-    }).compile();
+      providers: [InstallationDbService, InstallationHttpService, ServerDbService],
+    })
+      .overrideProvider(InstallationDbService)
+      .useValue(mockInstallationDbService)
+      .overrideProvider(InstallationHttpService)
+      .useValue(mockInstallationHttpService)
+      .overrideProvider(ServerDbService)
+      .useValue(mockServerDbService)
+      .compile();
 
     controller = module.get<InstallationController>(InstallationController);
   });

--- a/apps/emby-data-check-api/src/app/installation/service/installation-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/installation/service/installation-db.service.spec.ts
@@ -1,18 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { InstallationEntity } from '../models/installation.entity';
 import { InstallationDbService } from './installation-db.service';
 
 describe('InstallationService', () => {
   let service: InstallationDbService;
 
-  const mockInstallationDbService = {};
+  const mockInstallationEntityRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [InstallationDbService],
-    })
-      .overrideProvider(InstallationDbService)
-      .useValue(mockInstallationDbService)
-      .compile();
+      providers: [InstallationDbService, { provide: getRepositoryToken(InstallationEntity), useValue: mockInstallationEntityRepository }],
+    }).compile();
 
     service = module.get<InstallationDbService>(InstallationDbService);
   });

--- a/apps/emby-data-check-api/src/app/installation/service/installation-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/installation/service/installation-db.service.spec.ts
@@ -4,10 +4,15 @@ import { InstallationDbService } from './installation-db.service';
 describe('InstallationService', () => {
   let service: InstallationDbService;
 
+  const mockInstallationDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [InstallationDbService],
-    }).compile();
+    })
+      .overrideProvider(InstallationDbService)
+      .useValue(mockInstallationDbService)
+      .compile();
 
     service = module.get<InstallationDbService>(InstallationDbService);
   });

--- a/apps/emby-data-check-api/src/app/installation/service/installation-http.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/installation/service/installation-http.service.spec.ts
@@ -4,10 +4,15 @@ import { InstallationHttpService } from './installation-http.service';
 describe('InstallationHttpService', () => {
   let service: InstallationHttpService;
 
+  const mockInstallationHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [InstallationHttpService],
-    }).compile();
+    })
+      .overrideProvider(InstallationHttpService)
+      .useValue(mockInstallationHttpService)
+      .compile();
 
     service = module.get<InstallationHttpService>(InstallationHttpService);
   });

--- a/apps/emby-data-check-api/src/app/media-item/controller/media-item.controller.spec.ts
+++ b/apps/emby-data-check-api/src/app/media-item/controller/media-item.controller.spec.ts
@@ -1,13 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ServerDbService } from '../../server/service/server-db.service';
+import { MediaItemDbService } from '../service/media-item-db.service';
+import { MediaItemHttpService } from '../service/media-item-http.service';
 import { MediaItemController } from './media-item.controller';
 
 describe('MediaItemController', () => {
   let controller: MediaItemController;
 
+  const mockMediaItemDbService = {};
+  const mockMediaItemHttpService = {};
+  const mockServerDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MediaItemController],
-    }).compile();
+      providers: [MediaItemDbService, MediaItemHttpService, ServerDbService],
+    })
+      .overrideProvider(MediaItemDbService)
+      .useValue(mockMediaItemDbService)
+      .overrideProvider(MediaItemHttpService)
+      .useValue(mockMediaItemHttpService)
+      .overrideProvider(ServerDbService)
+      .useValue(mockServerDbService)
+      .compile();
 
     controller = module.get<MediaItemController>(MediaItemController);
   });

--- a/apps/emby-data-check-api/src/app/media-item/service/media-item-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/media-item/service/media-item-db.service.spec.ts
@@ -1,18 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MediaItemEntity } from '../models/media-item.entity';
 import { MediaItemDbService } from './media-item-db.service';
 
 describe('MediaItemService', () => {
   let service: MediaItemDbService;
 
-  const mockMediaItemDbService = {};
+  const mockMediaItemEntityRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [MediaItemDbService],
-    })
-      .overrideProvider(MediaItemDbService)
-      .useValue(mockMediaItemDbService)
-      .compile();
+      providers: [MediaItemDbService, { provide: getRepositoryToken(MediaItemEntity), useValue: mockMediaItemEntityRepository }],
+    }).compile();
 
     service = module.get<MediaItemDbService>(MediaItemDbService);
   });

--- a/apps/emby-data-check-api/src/app/media-item/service/media-item-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/media-item/service/media-item-db.service.spec.ts
@@ -4,10 +4,15 @@ import { MediaItemDbService } from './media-item-db.service';
 describe('MediaItemService', () => {
   let service: MediaItemDbService;
 
+  const mockMediaItemDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [MediaItemDbService],
-    }).compile();
+    })
+      .overrideProvider(MediaItemDbService)
+      .useValue(mockMediaItemDbService)
+      .compile();
 
     service = module.get<MediaItemDbService>(MediaItemDbService);
   });

--- a/apps/emby-data-check-api/src/app/media-item/service/media-item-http.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/media-item/service/media-item-http.service.spec.ts
@@ -4,10 +4,15 @@ import { MediaItemHttpService } from './media-item-http.service';
 describe('MediaItemHttpService', () => {
   let service: MediaItemHttpService;
 
+  const mockMediaItemHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [MediaItemHttpService],
-    }).compile();
+    })
+      .overrideProvider(MediaItemHttpService)
+      .useValue(mockMediaItemHttpService)
+      .compile();
 
     service = module.get<MediaItemHttpService>(MediaItemHttpService);
   });

--- a/apps/emby-data-check-api/src/app/server/controller/server.controller.spec.ts
+++ b/apps/emby-data-check-api/src/app/server/controller/server.controller.spec.ts
@@ -1,13 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ServerDbService } from '../service/server-db.service';
+import { ServerHttpService } from '../service/server-http.service';
 import { ServerController } from './server.controller';
 
 describe('ServerController', () => {
   let controller: ServerController;
 
+  const mockServerDbService = {};
+  const mockServerHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ServerController],
-    }).compile();
+      providers: [ServerDbService, ServerHttpService],
+    })
+      .overrideProvider(ServerDbService)
+      .useValue(mockServerDbService)
+      .overrideProvider(ServerHttpService)
+      .useValue(mockServerHttpService)
+      .compile();
 
     controller = module.get<ServerController>(ServerController);
   });

--- a/apps/emby-data-check-api/src/app/server/service/server-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/server/service/server-db.service.spec.ts
@@ -4,10 +4,15 @@ import { ServerDbService } from './server-db.service';
 describe('ServerDbService', () => {
   let service: ServerDbService;
 
+  const mockServerDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ServerDbService],
-    }).compile();
+    })
+      .overrideProvider(ServerDbService)
+      .useValue(mockServerDbService)
+      .compile();
 
     service = module.get<ServerDbService>(ServerDbService);
   });

--- a/apps/emby-data-check-api/src/app/server/service/server-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/server/service/server-db.service.spec.ts
@@ -1,18 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ServerEntity } from '../models/server.entity';
 import { ServerDbService } from './server-db.service';
 
 describe('ServerDbService', () => {
   let service: ServerDbService;
 
-  const mockServerDbService = {};
+  const mockServerEntityRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ServerDbService],
-    })
-      .overrideProvider(ServerDbService)
-      .useValue(mockServerDbService)
-      .compile();
+      providers: [ServerDbService, { provide: getRepositoryToken(ServerEntity), useValue: mockServerEntityRepository }],
+    }).compile();
 
     service = module.get<ServerDbService>(ServerDbService);
   });

--- a/apps/emby-data-check-api/src/app/server/service/server-http.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/server/service/server-http.service.spec.ts
@@ -4,10 +4,15 @@ import { ServerHttpService } from './server-http.service';
 describe('ServerHttpService', () => {
   let service: ServerHttpService;
 
+  const mockServerHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ServerHttpService],
-    }).compile();
+    })
+      .overrideProvider(ServerHttpService)
+      .useValue(mockServerHttpService)
+      .compile();
 
     service = module.get<ServerHttpService>(ServerHttpService);
   });

--- a/apps/emby-data-check-api/src/app/user/controller/user.controller.spec.ts
+++ b/apps/emby-data-check-api/src/app/user/controller/user.controller.spec.ts
@@ -1,13 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UserDbService } from '../service/user-db.service';
+import { UserHttpService } from '../service/user-http.service';
 import { UserController } from './user.controller';
 
 describe('UserController', () => {
   let controller: UserController;
 
+  const mockUserDbService = {};
+  const mockUserHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-    }).compile();
+      providers: [UserDbService, UserHttpService],
+    })
+      .overrideProvider(UserDbService)
+      .useValue(mockUserDbService)
+      .overrideProvider(UserHttpService)
+      .useValue(mockUserHttpService)
+      .compile();
 
     controller = module.get<UserController>(UserController);
   });

--- a/apps/emby-data-check-api/src/app/user/service/user-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/user/service/user-db.service.spec.ts
@@ -4,10 +4,15 @@ import { UserDbService } from './user-db.service';
 describe('UserDbService', () => {
   let service: UserDbService;
 
+  const mockUserDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [UserDbService],
-    }).compile();
+    })
+      .overrideProvider(UserDbService)
+      .useValue(mockUserDbService)
+      .compile();
 
     service = module.get<UserDbService>(UserDbService);
   });

--- a/apps/emby-data-check-api/src/app/user/service/user-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/user/service/user-db.service.spec.ts
@@ -1,18 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserEntity } from '../models/user.entity';
 import { UserDbService } from './user-db.service';
 
 describe('UserDbService', () => {
   let service: UserDbService;
 
-  const mockUserDbService = {};
+  const mockUserEntityRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserDbService],
-    })
-      .overrideProvider(UserDbService)
-      .useValue(mockUserDbService)
-      .compile();
+      providers: [UserDbService, { provide: getRepositoryToken(UserEntity), useValue: mockUserEntityRepository }],
+    }).compile();
 
     service = module.get<UserDbService>(UserDbService);
   });

--- a/apps/emby-data-check-api/src/app/user/service/user-http.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/user/service/user-http.service.spec.ts
@@ -4,10 +4,15 @@ import { UserHttpService } from './user-http.service';
 describe('UserHttpService', () => {
   let service: UserHttpService;
 
+  const mockUserHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [UserHttpService],
-    }).compile();
+    })
+      .overrideProvider(UserHttpService)
+      .useValue(mockUserHttpService)
+      .compile();
 
     service = module.get<UserHttpService>(UserHttpService);
   });

--- a/apps/emby-data-check-api/src/app/watch-state/controller/watch-state.controller.spec.ts
+++ b/apps/emby-data-check-api/src/app/watch-state/controller/watch-state.controller.spec.ts
@@ -1,13 +1,32 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EmbyUserDbService } from '../../emby-user/service/emby-user-db.service';
+import { ServerDbService } from '../../server/service/server-db.service';
+import { WatchStateDbService } from '../service/watch-state-db.service';
+import { WatchStateHttpService } from '../service/watch-state-http.service';
 import { WatchStateController } from './watch-state.controller';
 
 describe('WatchStateController', () => {
   let controller: WatchStateController;
 
+  const mockWatchStateDbService = {};
+  const mockWatchStateHttpService = {};
+  const mockServerDbService = {};
+  const mockEmbyUserDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WatchStateController],
-    }).compile();
+      providers: [WatchStateDbService, WatchStateHttpService, ServerDbService, EmbyUserDbService],
+    })
+      .overrideProvider(WatchStateDbService)
+      .useValue(mockWatchStateDbService)
+      .overrideProvider(WatchStateHttpService)
+      .useValue(mockWatchStateHttpService)
+      .overrideProvider(ServerDbService)
+      .useValue(mockServerDbService)
+      .overrideProvider(EmbyUserDbService)
+      .useValue(mockEmbyUserDbService)
+      .compile();
 
     controller = module.get<WatchStateController>(WatchStateController);
   });

--- a/apps/emby-data-check-api/src/app/watch-state/service/watch-state-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/watch-state/service/watch-state-db.service.spec.ts
@@ -4,10 +4,15 @@ import { WatchStateDbService } from './watch-state-db.service';
 describe('WatchStateDbService', () => {
   let service: WatchStateDbService;
 
+  const mockWatchStateDbService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [WatchStateDbService],
-    }).compile();
+    })
+      .overrideProvider(WatchStateDbService)
+      .useValue(mockWatchStateDbService)
+      .compile();
 
     service = module.get<WatchStateDbService>(WatchStateDbService);
   });

--- a/apps/emby-data-check-api/src/app/watch-state/service/watch-state-db.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/watch-state/service/watch-state-db.service.spec.ts
@@ -1,18 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { WatchStateEntity } from '../models/watch-state.entity';
 import { WatchStateDbService } from './watch-state-db.service';
 
 describe('WatchStateDbService', () => {
   let service: WatchStateDbService;
 
-  const mockWatchStateDbService = {};
+  const mockWatchStateEntityRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [WatchStateDbService],
-    })
-      .overrideProvider(WatchStateDbService)
-      .useValue(mockWatchStateDbService)
-      .compile();
+      providers: [WatchStateDbService, { provide: getRepositoryToken(WatchStateEntity), useValue: mockWatchStateEntityRepository }],
+    }).compile();
 
     service = module.get<WatchStateDbService>(WatchStateDbService);
   });

--- a/apps/emby-data-check-api/src/app/watch-state/service/watch-state-http.service.spec.ts
+++ b/apps/emby-data-check-api/src/app/watch-state/service/watch-state-http.service.spec.ts
@@ -4,10 +4,15 @@ import { WatchStateHttpService } from './watch-state-http.service';
 describe('WatchStateHttpService', () => {
   let service: WatchStateHttpService;
 
+  const mockWatchStateHttpService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [WatchStateHttpService],
-    }).compile();
+    })
+      .overrideProvider(WatchStateHttpService)
+      .useValue(mockWatchStateHttpService)
+      .compile();
 
     service = module.get<WatchStateHttpService>(WatchStateHttpService);
   });


### PR DESCRIPTION
This PR changes the unit tests itself for the API parts. It covers the injection of dependencies (providers, repositories) for the several test files. This makes the unit tests pass for the workspace project `emby-data-check-api`