### PR TITLE
Improve docker build, complete app setup (take over from backup)

### DIFF
--- a/apps/edc-ui-ng/src/index.html
+++ b/apps/edc-ui-ng/src/index.html
@@ -6,9 +6,12 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   </head>
 
-  <body>
+  <body class="mat-typography">
     <edc-ng-root></edc-ng-root>
   </body>
 </html>

--- a/apps/edc-ui-ng/src/styles.scss
+++ b/apps/edc-ui-ng/src/styles.scss
@@ -1,1 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
+html,
+body {
+  height: 100%;
+}
+body {
+  margin: 0;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+}

--- a/docker/Dockerfile.prod.edc-api
+++ b/docker/Dockerfile.prod.edc-api
@@ -20,7 +20,7 @@ COPY --chown=node:node nx.json .
 COPY --chown=node:node package.json .
 COPY --chown=node:node package-lock.json .
 
-RUN npm install --ignore-scripts
+RUN npm install --ignore-scripts --production
 
 # upload the compiled data -> changes more often than versions
 COPY --chown=node:node ./apps ./apps
@@ -31,6 +31,9 @@ RUN npx nx build --project=edc-api --verbose
 # Remove unnecessary files from ./node_modules -> folder will be copied later
 RUN npm prune --production
 RUN /usr/local/bin/node-prune
+
+# List file sizes of ./node_modules/* content
+RUN du -sh ./node_modules/* | sort -nr
 
 ### -------------------- ###
 FROM node:18.15.0-alpine

--- a/docker/Dockerfile.prod.edc-ui-fundamentals
+++ b/docker/Dockerfile.prod.edc-ui-fundamentals
@@ -13,13 +13,16 @@ COPY --chown=node:node nx.json .
 COPY --chown=node:node package.json .
 COPY --chown=node:node package-lock.json .
 
-RUN npm install --ignore-scripts
+RUN npm install --ignore-scripts --production
 
 # upload the compiled data -> changes more often than versions
 COPY --chown=node:node ./apps ./apps
 COPY --chown=node:node ./libs ./libs
 
 RUN npx nx build --project=edc-ui-fundamentals --verbose
+
+# List file sizes of ./node_modules/* content
+RUN du -sh ./node_modules/* | sort -nr
 
 ## -------------------- ###
 FROM nginx:1.23.2-alpine

--- a/docker/Dockerfile.prod.edc-ui-ng
+++ b/docker/Dockerfile.prod.edc-ui-ng
@@ -13,13 +13,16 @@ COPY --chown=node:node nx.json .
 COPY --chown=node:node package.json .
 COPY --chown=node:node package-lock.json .
 
-RUN npm install --ignore-scripts
+RUN npm install --ignore-scripts --production
 
 # upload the compiled data -> changes more often than versions
 COPY --chown=node:node ./apps ./apps
 COPY --chown=node:node ./libs ./libs
 
 RUN npx nx build --project=edc-ui-ng --verbose
+
+# List file sizes of ./node_modules/* content
+RUN du -sh ./node_modules/* | sort -nr
 
 ## -------------------- ###
 FROM nginx:1.23.2-alpine


### PR DESCRIPTION
* The docker build process is enhanced by:
  * setting the flag `-production` at command `npm install`
  * print the size of items in folder `node_modules`, so that there we find useless content, which can be removed manually as well

* The UI apps are now set up in an initial state. Now, regular development can continue again.

But we first finalize the formal stuff.