### PR TITLE
Replace script to detect changes for docker publish

### DIFF
--- a/.github/actions/detect-changes-to-docker/action.yml
+++ b/.github/actions/detect-changes-to-docker/action.yml
@@ -25,7 +25,7 @@ runs:
       id: findAffectedFromNx
       shell: bash
       run: |
-        echo "npx nx print-affected --base=${{ env.BASE }} --head=${{ env.HEAD }} --select=projects" >> $GITHUB_OUTPUT
+        echo "affected=${{ npx nx print-affected --base=${{ env.BASE }} --head=${{ env.HEAD }} --select=projects }}" >> $GITHUB_OUTPUT
 
     - name: 'Is a new image required?'
       id: need-new-image


### PR DESCRIPTION
After upgrading to Nx@v16, the change detection for building docker images doesn't work properly. With this PR, we are replacing the usage of a seperate github action by a bash script.