### PR TITLE
chore(repo): add workflow to label PRs

### DIFF
--- a/.github/labeler_config.yml
+++ b/.github/labeler_config.yml
@@ -1,0 +1,5 @@
+dependencies:
+  - package.json
+  - package-lock.json
+  - .nvmrc
+  - .npmrc

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: 'Pull Request Labeler'
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: 'Label Pull-Requests'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Add labels'
+        uses: actions/labeler@v4.3.0
+        with:
+          configuration-path: .github/labeler_config.yml
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true


### PR DESCRIPTION
Add a labeler for Pull Requests. Currently, it's only configured for dependencies. But others may follow.