### PR TITLE
chore(repo): introduce grouping for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,20 @@ updates:
     target-branch: 'main'
     labels:
       - 'dependencies'
+    groups:
+      angular:
+        patterns:
+          - '@angular*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      nx:
+        patterns:
+          - '@nx*'
+          - 'nx*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Dependabot alerts for angular or nx packages will be grouped into single PRs. This reduces the amount of PRs after each dependabot run.