### PR TITLE
Migrations for TypeOrm

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,9 +1,11 @@
 # Configuration for NestJs API
+API_PORT=
 DATABASE_HOST=
 DATABASE_NAME=
 DATABASE_PASSWORD=
 DATABASE_PORT=
 DATABASE_USERNAME=
+MIGRATIONS_TABLE_NAME=
 
 # Configuration for Docker Containers
 ## PgAdmin4 Web Console

--- a/apps/edc-api/db/migrations.config.ts
+++ b/apps/edc-api/db/migrations.config.ts
@@ -8,16 +8,16 @@ const configService = new ConfigService();
 
 const dataSourceConfig: DataSourceOptions = {
   type: 'postgres',
-  host: configService.get('DATABASE_HOST'),
-  port: configService.get('DATABASE_PORT'),
-  username: configService.get('DATABASE_USERNAME'),
-  password: configService.get('DATABASE_PASSWORD'),
-  database: configService.get('DATABASE_NAME'),
+  host: configService.get<string>('DATABASE_HOST'),
+  port: configService.get<number>('DATABASE_PORT'),
+  username: configService.get<string>('DATABASE_USERNAME'),
+  password: configService.get<string>('DATABASE_PASSWORD'),
+  database: configService.get<string>('DATABASE_NAME'),
   entities: [`${__dirname}/../src/**/*.entity{.ts,.js}`],
-  synchronize: configService.get('tier') === 'development',
-  logging: configService.get('tier') === 'development',
+  synchronize: configService.get<string>('tier') === 'development',
+  logging: configService.get<string>('tier') === 'development',
   migrations: [`${__dirname}/migrations/*{.ts,.js}`],
-  migrationsTableName: configService.get('MIGRATIONS_TABLE_NAME'),
+  migrationsTableName: configService.get<string>('MIGRATIONS_TABLE_NAME'),
 };
 
 export default new DataSource(dataSourceConfig);

--- a/apps/edc-api/db/migrations.config.ts
+++ b/apps/edc-api/db/migrations.config.ts
@@ -1,0 +1,23 @@
+import { ConfigService } from '@nestjs/config';
+import { config } from 'dotenv';
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+config();
+
+const configService = new ConfigService();
+
+const dataSourceConfig: DataSourceOptions = {
+  type: 'postgres',
+  host: configService.get('DATABASE_HOST'),
+  port: configService.get('DATABASE_PORT'),
+  username: configService.get('DATABASE_USERNAME'),
+  password: configService.get('DATABASE_PASSWORD'),
+  database: configService.get('DATABASE_NAME'),
+  entities: [`${__dirname}/../src/**/*.entity{.ts,.js}`],
+  synchronize: configService.get('tier') === 'development',
+  logging: configService.get('tier') === 'development',
+  migrations: [`${__dirname}/migrations/*{.ts,.js}`],
+  migrationsTableName: configService.get('MIGRATIONS_TABLE_NAME'),
+};
+
+export default new DataSource(dataSourceConfig);

--- a/apps/edc-api/src/app/app.module.ts
+++ b/apps/edc-api/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { AppConfig, DatabaseConfig } from './config';
     ConfigModule.forRoot({
       isGlobal: true,
       cache: true,
+      expandVariables: true,
       load: [AppConfig, DatabaseConfig],
     }),
     TypeOrmModule.forRootAsync({

--- a/apps/edc-api/src/app/app.module.ts
+++ b/apps/edc-api/src/app/app.module.ts
@@ -1,11 +1,28 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ServerFeatureHealthModule } from 'api/feature-health';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { ServerFeatureHealthModule } from 'api/feature-health';
+import { AppConfig, DatabaseConfig } from './config';
 
 @Module({
-  imports: [ServerFeatureHealthModule],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      cache: true,
+      load: [AppConfig, DatabaseConfig],
+    }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        ...configService.get('database'),
+      }),
+      inject: [ConfigService],
+    }),
+    ServerFeatureHealthModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/edc-api/src/app/config/app.config.ts
+++ b/apps/edc-api/src/app/config/app.config.ts
@@ -1,0 +1,6 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('config', () => ({
+  port: parseInt(process.env.API_PORT, 10) || 3000,
+  tier: process.env.NODE_ENV,
+}));

--- a/apps/edc-api/src/app/config/database.config.ts
+++ b/apps/edc-api/src/app/config/database.config.ts
@@ -1,0 +1,15 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('database', () => ({
+  type: 'postgres',
+  host: process.env.DATABASE_HOST || 'localhost',
+  port: parseInt(process.env.DATABASE_PORT, 10) || 5432,
+  username: process.env.DATABASE_USERNAME,
+  password: process.env.DATABASE_PASSWORD,
+  database: process.env.DATABASE_NAME,
+  entities: [`${__dirname}/../entities/**/*.entity{.ts,.js}`],
+  synchronize: process.env.NODE_ENV === 'development',
+  logging: process.env.NODE_ENV === 'development',
+  migrations: [`${__dirname}/../../../db/migrations/*{.ts,.js}`],
+  migrationsTableName: process.env.MIGRATIONS_TABLE_NAME,
+}));

--- a/apps/edc-api/src/app/config/index.ts
+++ b/apps/edc-api/src/app/config/index.ts
@@ -1,0 +1,2 @@
+export { default as AppConfig } from './app.config';
+export { default as DatabaseConfig } from './database.config';

--- a/apps/edc-api/src/main.ts
+++ b/apps/edc-api/src/main.ts
@@ -4,6 +4,7 @@
  */
 
 import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerCustomOptions, SwaggerDocumentOptions, SwaggerModule } from '@nestjs/swagger';
 
@@ -12,7 +13,9 @@ import { AppModule } from './app/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  const port = process.env.PORT || 3000;
+
+  const configService = app.get(ConfigService);
+  const port = configService.get('config.port');
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,13 @@
     "stack:nord": "nx run edc-ui-nord:stack",
     "test:affected": "nx affected:test --parallel",
     "test:all": "nx run-many --target=test --parallel --all",
+    "typeorm": "ts-node -P tsconfig.orm.json ./node_modules/typeorm/cli",
+    "typeorm:config": "npm run typeorm -- -d ./apps/edc-api/db/migrations.config.ts",
+    "typeorm:migration:create": "npm run typeorm -- migration:create ./apps/edc-api/db/migrations/$npm_config_name",
+    "typeorm:migration:generate": "npm run typeorm -- migration:generate -d ./apps/edc-api/db/migrations.config.ts ./apps/edc-api/db/migrations/$npm_config_name",
+    "typeorm:migration:revert": "npm run typeorm:config -- migration:revert",
+    "typeorm:migration:run": "npm run typeorm:config -- migration:run",
+    "typeorm:migration:show": "npm run typeorm:config -- migration:show",
     "upgrade": "nx migrate latest --interactive",
     "upgrade:doit": "npm install && nx migrate --run-migrations"
   },

--- a/tsconfig.orm.json
+++ b/tsconfig.orm.json
@@ -1,0 +1,19 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "ES2015",
+    "module": "CommonJS",
+    "lib": ["ES2017", "DOM"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": "./"
+  },
+  "exclude": ["./node_modules", "tmp"]
+}


### PR DESCRIPTION
The integration for TypeORM databases and their setup with migrations is supported now. There are several new scripts in the `package.json` file dealing with different scenarios. It supports configuration by `.env`-file as well as environment library (more static settings).