### PR TITLE
Fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: 'docker'
-    directory: '/apps/**/Dockerfile'
-    schedule:
-      interval: 'monthly'
-    open-pull-requests-limit: 3
-    target-branch: 'main'
-    labels:
-      - 'dependencies'
-
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
This PR will remove the docker package-ecosystem from the dependabot configuration. As there was a glob file pattern in the configuration, it was failing.
