### PR TITLE
Add formatting check in pipeline

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -110,3 +110,10 @@ jobs:
           echo "Triggered manually (from workflow inputs)"
           echo "Is app [edc-api] affected? ${{ inputs.edc-api-manual }}"
           echo "Is app [edc-ui-ng] affected? ${{ inputs.edc-ui-ng-manual }}"
+
+      - name: 'Check formatting'
+        id: formatting-check
+        env:
+          headSha: ${{ github.sha }}
+          nxBase: ${{ steps.extract-branch.outputs.nxBase }}
+        run: npx nx format:check --base=remotes/origin/$nxBase --head=$headSha

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,12 +137,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1901.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1901.7.tgz",
-      "integrity": "sha512-qltyebfbej7joIKZVH8EFfrVDrkw0p9N9ja3A0XeU1sl2vlepHNAQdVm0Os8Vy2XjjyHvT5bXWE3G3/221qEKw==",
+      "version": "0.1901.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1901.8.tgz",
+      "integrity": "sha512-DzvlL1Zg+zOnVmMN3CjE5KzjZAltRZwOwwcso72iWenBPvl/trKzPDlA6ySmpRonm+AR9i9JrdLEUlwczW6/bQ==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.7",
+        "@angular-devkit/core": "19.1.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -151,17 +151,26 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular-devkit/architect/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.1.7.tgz",
-      "integrity": "sha512-CMl3D5cpXoY0WuvdYtuOU2TetCwqxNsYM2jpuGG/kuuTEASAOI1cs9OhGwny1A/63bB8eyL33eLe82ON2Oemow==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.1.8.tgz",
+      "integrity": "sha512-LPKbxjW6ZjyujnL/lbkecxEFVoV1ItKNsrlsHU6kq0LsR4/DsIgstnHVIG9KoyJV++IM144TWB1Cr4/Jaxxu+w==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1901.7",
-        "@angular-devkit/build-webpack": "0.1901.7",
-        "@angular-devkit/core": "19.1.7",
-        "@angular/build": "19.1.7",
+        "@angular-devkit/architect": "0.1901.8",
+        "@angular-devkit/build-webpack": "0.1901.8",
+        "@angular-devkit/core": "19.1.8",
+        "@angular/build": "19.1.8",
         "@babel/core": "7.26.0",
         "@babel/generator": "7.26.3",
         "@babel/helper-annotate-as-pure": "7.25.9",
@@ -172,7 +181,7 @@
         "@babel/preset-env": "7.26.0",
         "@babel/runtime": "7.26.0",
         "@discoveryjs/json-ext": "0.6.3",
-        "@ngtools/webpack": "19.1.7",
+        "@ngtools/webpack": "19.1.8",
         "@vitejs/plugin-basic-ssl": "1.2.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.20",
@@ -226,7 +235,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.1.7",
+        "@angular/ssr": "^19.1.8",
         "@web/test-runner": "^0.19.0",
         "browser-sync": "^3.0.2",
         "jest": "^29.5.0",
@@ -335,6 +344,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -400,12 +418,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1901.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1901.7.tgz",
-      "integrity": "sha512-g7xPN7unBnqP9HsgFvEV1DIhNYmVwmWR9ZiSP0xJq+EjpjWlz2vmgru4a5WKwGeuLsP8vg7RKV0kCH3bunOmFA==",
+      "version": "0.1901.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1901.8.tgz",
+      "integrity": "sha512-SmuGtTqrm43LiJ+ldAuq/QKyLPt2fS1nfnLTo+zTwgt/YAK+ps8cTPG/FqrURfXXWxgtAaeFX5B+samk8TSuvQ==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1901.7",
+        "@angular-devkit/architect": "0.1901.8",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -418,10 +436,19 @@
         "webpack-dev-server": "^5.0.2"
       }
     },
+    "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@angular-devkit/core": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.7.tgz",
-      "integrity": "sha512-q0I6L9KTqyQ7D5M8H+fWLT+yjapvMNb7SRdfU6GzmexO66Dpo83q4HDzuDKIPDF29Yl0ELs9ICJqe9yUXh6yDQ==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.8.tgz",
+      "integrity": "sha512-j1zHKvOsGwu5YwAZGuzi835R9vcW7PkfxmSRIJeVl+vawgk31K3zFb4UPH8AY/NPWYqXIAnwpka3HC1+JrWLWA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",
@@ -445,13 +472,22 @@
         }
       }
     },
+    "node_modules/@angular-devkit/core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.1.7.tgz",
-      "integrity": "sha512-AP6FvhMybCYs3gs+vzEAzSU1K//AFT3SVTRFv+C3WMO5dLeAHeGzM8I2dxD5EHQQtqIE/8apP6CxGrnpA5YlFg==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.1.8.tgz",
+      "integrity": "sha512-2JGUMD3zjfY8G4RYpypm2/1YEO+O4DtFycUvptIpsBYyULgnEbJ3tlp2oRiXI2vp9tC8IyWqa/swlA8DTI6ZYQ==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.7",
+        "@angular-devkit/core": "19.1.8",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -461,6 +497,15 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular-eslint/builder": {
@@ -590,9 +635,9 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.1.6.tgz",
-      "integrity": "sha512-iacosz3fygp0AyT57+suVpLChl10xS5RBje09TfQIKHTUY0LWkMspgaK9gwtlflpIhjedPV0UmgRIKhhFcQM1A==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.1.8.tgz",
+      "integrity": "sha512-sxicBdNvqjoInqGnT4C3qBJ7G3/NilWIbBJB1SGgnk3eHBHX8DJH0D/kQKVfN1OSuAVPpRc1qqz2zpPbf3I8bA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -601,18 +646,18 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.1.6"
+        "@angular/core": "19.1.8"
       }
     },
     "node_modules/@angular/build": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.1.7.tgz",
-      "integrity": "sha512-22SjHZDTk91JHU5aFVDU2n+xkPolDosRVfsK4zs+RRXQs30LYPH9KCLiUWCYjFbRj7oYvw7sbrs94szo7dWYvw==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-19.1.8.tgz",
+      "integrity": "sha512-DAnnmbqPmtlY5JOitqWUgXi/yKj8eAcrP0T7hYZwLmcRsb+HsHYWsAQoFaTDw0p9WC5BKPqDBCMIivcuIV/izQ==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1901.7",
-        "@angular-devkit/core": "19.1.7",
+        "@angular-devkit/architect": "0.1901.8",
+        "@angular-devkit/core": "19.1.8",
         "@babel/core": "7.26.0",
         "@babel/helper-annotate-as-pure": "7.25.9",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -651,7 +696,7 @@
         "@angular/localize": "^19.0.0",
         "@angular/platform-server": "^19.0.0",
         "@angular/service-worker": "^19.0.0",
-        "@angular/ssr": "^19.1.7",
+        "@angular/ssr": "^19.1.8",
         "less": "^4.2.0",
         "ng-packagr": "^19.0.0",
         "postcss": "^8.4.0",
@@ -757,9 +802,9 @@
       }
     },
     "node_modules/@angular/cdk": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.1.4.tgz",
-      "integrity": "sha512-PyvJ1VbYjW8tVnVHvcasiqI9eNWf8EJnr0in1QWnhpSbpVpVpc4yjbgnu2pTrW9mPo/YjV4pF+qs6E97y9mdYQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.1.tgz",
+      "integrity": "sha512-j7dg18PJIbyeU4DTko3vIK3M2OuUv3H0ZViNddOaLlGN5X93cq4QCGcNhcGm3x3r5rUr/AaexYu+KHMyN8PwmA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -774,18 +819,18 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.1.7.tgz",
-      "integrity": "sha512-qVEy0R4QKQ2QAGfpj2mPVxRxgOVst+rIgZBtLwf/mrbN9YyzJUaBKvaVslUpOqkvoW9mX5myf0iZkT5NykrIoA==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.1.8.tgz",
+      "integrity": "sha512-JmdLj8110DNWaxL03K7I06+nLyBfXgiIqYyrQx5QO9AodGkKHK5rE+7VD8MjZhUymua57HToD0oHaQgThJwTJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1901.7",
-        "@angular-devkit/core": "19.1.7",
-        "@angular-devkit/schematics": "19.1.7",
+        "@angular-devkit/architect": "0.1901.8",
+        "@angular-devkit/core": "19.1.8",
+        "@angular-devkit/schematics": "19.1.8",
         "@inquirer/prompts": "7.2.1",
         "@listr2/prompt-adapter-inquirer": "2.0.18",
-        "@schematics/angular": "19.1.7",
+        "@schematics/angular": "19.1.8",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "5.0.0",
         "jsonc-parser": "3.3.1",
@@ -808,9 +853,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.1.6.tgz",
-      "integrity": "sha512-FkuejwbxsOLhcyOgDM/7YEYvMG3tuyOvr+831VzPwMwYp5QO9AUYtn4ffGf698JccbA+Ocw3BAdhPU6i+YZC1A==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.1.8.tgz",
+      "integrity": "sha512-JTErVPLOQ+S1AbzUzHvgwqreiYltKI2yBRVUaiKSvutuu5zRvePmw0Ybo49DygkU9IT0E+CN8EzXp1WtaUGXxQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -819,14 +864,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.1.6",
+        "@angular/core": "19.1.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.1.6.tgz",
-      "integrity": "sha512-Tl2PFEtnU8UgSqtEKG827xDUGZrErhR6S1JICeV1kbRCYmwQA4hhG25tzi+ifSAOPW7eJiyzP2LWIvOuZkq3Vw==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.1.8.tgz",
+      "integrity": "sha512-KeCnzRwqavoKR5HZR7khaMf1XE330GuJULgL5x8XXsVPtb3x1i93md/JHr62VsPG6838S+5QmnWx8Z7hpSZF5A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -835,7 +880,7 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "19.1.6"
+        "@angular/core": "19.1.8"
       },
       "peerDependenciesMeta": {
         "@angular/core": {
@@ -844,9 +889,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.1.6.tgz",
-      "integrity": "sha512-rTpHC/tfLBj+5a3X+BA/4s2w5T/cHT6x3RgO8CYy7003Musn0/BiqjfE6VCIllQgLaOQRhCcf51T6Kerkzv8Dw==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.1.8.tgz",
+      "integrity": "sha512-Q1Y6zV2VDWhMNgtNcR2+AAG5xd8b1z+aRuGIKH6s0usDLE+OoOx1giOi8WJKvqVu/YHKhB9f42vYFoGf5fedEw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.0",
@@ -867,14 +912,14 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "19.1.6",
+        "@angular/compiler": "19.1.8",
         "typescript": ">=5.5 <5.8"
       }
     },
     "node_modules/@angular/core": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.1.6.tgz",
-      "integrity": "sha512-FD167URT+apxjzj9sG/MzffW5G6YyQiPQ6nrrIoYi9jeY3LYurybuOgvcXrU8PT4Z3+CKMq9k/ZnmrlHU72BpA==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.1.8.tgz",
+      "integrity": "sha512-mhLQDpKNvg5ou15OMwAAqmdHnmms1c+2beShRj0+sKa8EdPC9Xrz0SFWuSEX6tUEtKbtRpaxKFczx/VtuOZ5OA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -888,9 +933,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.1.6.tgz",
-      "integrity": "sha512-uu/76KAwCAcDuhD67Vv78UvOC/tiprtFXOgqNCj0LK8vyFcvPsunb3nF/PtfF9rSHyslXAqxZhME+Ha2tU6Lpw==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.1.8.tgz",
+      "integrity": "sha512-APmeoMg2IIsdf29MfLr04kSAFDnlfyRmI0gIXn31mvO7pWJgcwEOMmCC7xTbvfXzwY8u0W5+iASwqQajhyx90w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -899,16 +944,16 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.1.6",
-        "@angular/core": "19.1.6",
-        "@angular/platform-browser": "19.1.6",
+        "@angular/common": "19.1.8",
+        "@angular/core": "19.1.8",
+        "@angular/platform-browser": "19.1.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/language-service": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-19.1.6.tgz",
-      "integrity": "sha512-YIvCQRt+EFUKmms8M9K0ULDxAkCQSJqmnx4lGDJDHNK13U/C6r0d3/WMrrSDuSjax4zGSJf5xiRPpQlzPPsphA==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-19.1.8.tgz",
+      "integrity": "sha512-JwHo5yHYFbIhkRSoBZY7j29CX6DafscqSbUzurpjq3VRYHlAJ0A0vO0W60WGv2ClfSdh6uttlhiWl80NzDfWDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -916,16 +961,15 @@
       }
     },
     "node_modules/@angular/material": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.1.4.tgz",
-      "integrity": "sha512-bqliTnUnMiTG6Quvk16epiQPZQB0zV/L2ctPinFcP6NhahcQFfahjabUlgMlfBk5qObolJArJr5HCMiOmpOGIQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.1.tgz",
+      "integrity": "sha512-hA+HVIJn/y72vXv/X1JRbrL/tynW95wYMQF2fV3lIeeAmmFKkkzextBaE9rTaiW6pVN6LXoRvLJl2Vyi9jIHzw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/animations": "^19.0.0 || ^20.0.0",
-        "@angular/cdk": "19.1.4",
+        "@angular/cdk": "19.2.1",
         "@angular/common": "^19.0.0 || ^20.0.0",
         "@angular/core": "^19.0.0 || ^20.0.0",
         "@angular/forms": "^19.0.0 || ^20.0.0",
@@ -934,9 +978,9 @@
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.1.6.tgz",
-      "integrity": "sha512-sfWU+gMpqQ6GYtE3tAfDktftC01NgtqAOKfeCQ/KY2rxRTIxYahenW0Licuzgmd+8AZtmncoZaYX0Fd/5XMqzQ==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.1.8.tgz",
+      "integrity": "sha512-EPk3QVjvEiVpZiC/GiX18dmxpMyH6udqcLHh+dmYWYo3hUlxQCzRGzHg3hyaT5eaBL/8bjE6MkiDFlKchKRjEw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -945,9 +989,9 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.1.6",
-        "@angular/common": "19.1.6",
-        "@angular/core": "19.1.6"
+        "@angular/animations": "19.1.8",
+        "@angular/common": "19.1.8",
+        "@angular/core": "19.1.8"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -956,9 +1000,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.1.6.tgz",
-      "integrity": "sha512-QedjG7/ctPtzgJ3LcWv4yMcSivKlwcZ8ge8zPe7eu9Ft6mDZZat65gJEjDuvevJoeNbo2dQODFDiyPJNmnNA9A==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-19.1.8.tgz",
+      "integrity": "sha512-ZlfSdIejJB/NciC1BHCcMhQd3UKw98qjLGZPd2R6W3qYZ3iNc90xzdAAEpdmB/AH729QxZ1I1W5MWUDFZsZddg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -967,16 +1011,16 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.1.6",
-        "@angular/compiler": "19.1.6",
-        "@angular/core": "19.1.6",
-        "@angular/platform-browser": "19.1.6"
+        "@angular/common": "19.1.8",
+        "@angular/compiler": "19.1.8",
+        "@angular/core": "19.1.8",
+        "@angular/platform-browser": "19.1.8"
       }
     },
     "node_modules/@angular/platform-server": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-19.1.6.tgz",
-      "integrity": "sha512-yCFkByyHDtxXZaaaRV+268WN8s45ie+R5bcJ9oPKYE3Td0f/7iTRUatDfTI8h7/xbYK4nRgGZmxuiREpjt6y6Q==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-19.1.8.tgz",
+      "integrity": "sha512-4Ii3p0UjwKnDuCEosyQQMKiBdmgdrb36AjFTup1CbldtzqqKVjvZsJ/2tuoQ0ej5pOR1xaW19rEjwUJPjBNv2A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0",
@@ -986,17 +1030,17 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "19.1.6",
-        "@angular/common": "19.1.6",
-        "@angular/compiler": "19.1.6",
-        "@angular/core": "19.1.6",
-        "@angular/platform-browser": "19.1.6"
+        "@angular/animations": "19.1.8",
+        "@angular/common": "19.1.8",
+        "@angular/compiler": "19.1.8",
+        "@angular/core": "19.1.8",
+        "@angular/platform-browser": "19.1.8"
       }
     },
     "node_modules/@angular/router": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.1.6.tgz",
-      "integrity": "sha512-TEfw3W5jVodVDMD4krhXGog1THZN3x1yoh2oZmCv3lXg22+pVC6Cp+x3vVExq0mS+g3/6uZwy/3qAYdlzqYjTg==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.1.8.tgz",
+      "integrity": "sha512-EG92wVFbHL022jAtRZkhmh7pB8dWkjbu9qRgvcUOyAGxrsnN2k5xMA+lMKkNr3wzf3wIICiMvP2dnhp81Mb6Sg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1005,16 +1049,16 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "19.1.6",
-        "@angular/core": "19.1.6",
-        "@angular/platform-browser": "19.1.6",
+        "@angular/common": "19.1.8",
+        "@angular/core": "19.1.8",
+        "@angular/platform-browser": "19.1.8",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/ssr": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-19.1.7.tgz",
-      "integrity": "sha512-MNjjSWNv1K0E1K/U/pRgFo54n/1qyaFcYGYKSbnpwAGjtiCiHLudL3Dycke3mHTmcPFX61DniX1MdJtLhhFsVA==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-19.1.8.tgz",
+      "integrity": "sha512-mX00odH69coHobJf1wf/7sTnekTxiFy6MH3D4yHr6eS9BjI3TmJrmAp5gGsyWIQcc5Sdty6lEwmXS8AFZgnx3Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -3153,9 +3197,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.17.3.tgz",
-      "integrity": "sha512-6uOF726o3JnExAUKM20OJJXZo+Qf9Jt64nkVwnVXx7Upqr5I9Pb1npYPEAIpUA03SnWYmKwUIqhAmkwrN+bLPA==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.17.5.tgz",
+      "integrity": "sha512-b/Ntabar+g4gsRNwOct909cvatO/auHhNvBzJZfyFQzryI1nqHMaSFuDsrrtzbhQkGJ4GiMAKCXZC2EOdHMgmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3163,8 +3207,8 @@
         "@cspell/dict-al": "^1.1.0",
         "@cspell/dict-aws": "^4.0.9",
         "@cspell/dict-bash": "^4.2.0",
-        "@cspell/dict-companies": "^3.1.13",
-        "@cspell/dict-cpp": "^6.0.3",
+        "@cspell/dict-companies": "^3.1.14",
+        "@cspell/dict-cpp": "^6.0.4",
         "@cspell/dict-cryptocurrencies": "^5.0.4",
         "@cspell/dict-csharp": "^4.0.6",
         "@cspell/dict-css": "^4.0.17",
@@ -3174,14 +3218,14 @@
         "@cspell/dict-docker": "^1.1.12",
         "@cspell/dict-dotnet": "^5.0.9",
         "@cspell/dict-elixir": "^4.0.7",
-        "@cspell/dict-en_us": "^4.3.30",
+        "@cspell/dict-en_us": "^4.3.33",
         "@cspell/dict-en-common-misspellings": "^2.0.9",
         "@cspell/dict-en-gb": "1.1.33",
-        "@cspell/dict-filetypes": "^3.0.10",
+        "@cspell/dict-filetypes": "^3.0.11",
         "@cspell/dict-flutter": "^1.1.0",
         "@cspell/dict-fonts": "^4.0.4",
         "@cspell/dict-fsharp": "^1.1.0",
-        "@cspell/dict-fullstack": "^3.2.3",
+        "@cspell/dict-fullstack": "^3.2.5",
         "@cspell/dict-gaming-terms": "^1.1.0",
         "@cspell/dict-git": "^3.0.4",
         "@cspell/dict-golang": "^6.0.18",
@@ -3200,7 +3244,7 @@
         "@cspell/dict-markdown": "^2.0.9",
         "@cspell/dict-monkeyc": "^1.0.10",
         "@cspell/dict-node": "^5.0.6",
-        "@cspell/dict-npm": "^5.1.24",
+        "@cspell/dict-npm": "^5.1.27",
         "@cspell/dict-php": "^4.0.14",
         "@cspell/dict-powershell": "^5.0.14",
         "@cspell/dict-public-licenses": "^2.0.13",
@@ -3210,7 +3254,7 @@
         "@cspell/dict-rust": "^4.0.11",
         "@cspell/dict-scala": "^5.0.7",
         "@cspell/dict-shell": "^1.1.0",
-        "@cspell/dict-software-terms": "^4.2.4",
+        "@cspell/dict-software-terms": "^4.2.5",
         "@cspell/dict-sql": "^2.2.0",
         "@cspell/dict-svelte": "^1.0.6",
         "@cspell/dict-swift": "^2.0.5",
@@ -3223,22 +3267,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.17.3.tgz",
-      "integrity": "sha512-RWSfyHOin/d9CqLjz00JMvPkag3yUSsQZr6G9BnCT5cMEO/ws8wQZzA54CNj/LAOccbknTX65SSroPPAtxs56w==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-8.17.5.tgz",
+      "integrity": "sha512-+eVFCdnda74Frv8hguHYwDtxvqDuJJ/luFRl4dC5oknPMRab0JCHM1DDYjp3NzsehTex0HmcxplxqVW6QoDosg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.17.3"
+        "@cspell/cspell-types": "8.17.5"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.17.3.tgz",
-      "integrity": "sha512-DqqSWKt9NLWPGloYxZTpzUhgdW8ObMkZmOOF6TyqpJ4IbckEct8ULgskNorTNRlmmjLniaNgvg6JSHuYO3Urxw==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.17.5.tgz",
+      "integrity": "sha512-VOIfFdIo3FYQFcSpIyGkqHupOx0LgfBrWs79IKnTT1II27VUHPF+0oGq0WWf4c2Zpd8tzdHvS3IUhGarWZq69g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3246,9 +3290,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.17.3.tgz",
-      "integrity": "sha512-yQlVaIsWiax6RRuuacZs++kl6Y9rwH9ZkVlsG9fhdeCJ5Xf3WCW+vmX1chzhhKDzRr8CF9fsvb1uagd/5/bBYA==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.17.5.tgz",
+      "integrity": "sha512-5MhYInligPbGctWxoklAKxtg+sxvtJCuRKGSQHHA0JlCOLSsducypl780P6zvpjLK59XmdfC+wtFONxSmRbsuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3259,9 +3303,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.17.3.tgz",
-      "integrity": "sha512-CC3nob/Kbuesz5WTW+LjAHnDFXJrA49pW5ckmbufJxNnoAk7EJez/qr7/ELMTf6Fl3A5xZ776Lhq7738Hy/fmQ==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.17.5.tgz",
+      "integrity": "sha512-Ur3IK0R92G/2J6roopG9cU/EhoYAMOx2um7KYlq93cdrly8RBAK2NCcGCL7DbjQB6C9RYEAV60ueMUnQ45RrCQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3269,9 +3313,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.17.3.tgz",
-      "integrity": "sha512-ozgeuSioX9z2wtlargfgdw3LKwDFAfm8gxu+xwNREvXiLsevb+lb7ZlY5/ay+MahqR5Hfs7XzYzBLTKL/ldn9g==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.17.5.tgz",
+      "integrity": "sha512-91y2+0teunRSRZj940ORDA3kdjyenrUiM+4j6nQQH24sAIAJdRmQl2LG3eUTmeaSReJGkZIpnToQ6DyU5cC88Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3317,9 +3361,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.3.tgz",
-      "integrity": "sha512-OFrVXdxCeGKnon36Pe3yFjBuY4kzzEwWFf3vDz+cJTodZDkjFkBifQeTtt5YfimgF8cfAJZXkBCsxjipAgmAiw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.4.tgz",
+      "integrity": "sha512-IvXx3TlM+OL0CFriapk7ZHmeY89dSSdo/BZ3DGf+WUS+BWd64H+z/xr3xkkqY0Eu6MV/vdzNfkLm5zl45FDMGg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3394,9 +3438,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.3.31",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.31.tgz",
-      "integrity": "sha512-MDc+1B0aFwQONS0JZ6w7ks2KFGkUcaNTFJ8kI6GHvFRmEl3zP5NJDwFEXFsoEdLDb86j2myauSWMJXR3JFuwbA==",
+      "version": "4.3.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.33.tgz",
+      "integrity": "sha512-HniqQjzPVn24NEkHooBIw1cH+iO3AKMA9oDTwazUYQP1/ldqXsz6ce4+fdHia2nqypmic/lHVkQgIVhP48q/sA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3443,9 +3487,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-fullstack": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.4.tgz",
-      "integrity": "sha512-JRRvaOLBZ13BO9sP395W+06tyO1Jy/87aFlKe9xQiCWMiwpCo2kGq0xBGq0PDWe253lYLs+GKrNmLU0fSxrObg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.5.tgz",
+      "integrity": "sha512-XNmNdovPUS9Vc2JvfBscy8zZfwyxR11sB4fxU2lXh7LzUvOn2/OkKAzj41JTdiWfVnJ/yvsRkspe+b7kr+DIQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3582,9 +3626,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.1.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.26.tgz",
-      "integrity": "sha512-JU0/9P4nLPPC3Py+sF42tUKm9J4KAvwXaJubp2a4QwhCPzFVlOJTP2tTseFlLbdZn23d61pt0hZ+Jhyy7N76Mg==",
+      "version": "5.1.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.27.tgz",
+      "integrity": "sha512-LGss1yrjhxSmxL4VfMC+UBDMVHfqHudgC7b39M74EVys+nNC4/lqDHacb6Aw7i6aUn9mzdNIkdTTD+LdDcHvPA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3704,13 +3748,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.17.3.tgz",
-      "integrity": "sha512-Kg6IJhGHPv+9OxpxaXUpcqgnHEOhMLRWHLyx7FADZ+CJyO4AVeWQfhpTRM6KXhzIl7dPlLG1g8JAQxaoy88KTw==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.17.5.tgz",
+      "integrity": "sha512-tY+cVkRou+0VKvH+K1NXv8/R7mOlW3BDGSs9fcgvhatj0m00Yf8blFC7tE4VVI9Qh2bkC/KDFqM24IqZbuwXUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.17.3",
+        "@cspell/url": "8.17.5",
         "import-meta-resolve": "^4.1.0"
       },
       "engines": {
@@ -3718,9 +3762,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.17.3.tgz",
-      "integrity": "sha512-UFqRmJPccOSo+RYP/jZ4cr0s7ni37GrvnNAg1H/qIIxfmBYsexTAmsNzMqxp1M31NeI1Cx3LL7PspPMT0ms+7w==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-8.17.5.tgz",
+      "integrity": "sha512-Fj6py2Rl+FEnMiXhRQUM1A5QmyeCLxi6dY/vQ0qfH6tp6KSaBiaC8wuPUKhr8hKyTd3+8lkUbobDhUf6xtMEXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3728,9 +3772,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.17.3.tgz",
-      "integrity": "sha512-l/CaFc3CITI/dC+whEBZ05Om0KXR3V2whhVOWOBPIqA5lCjWAyvWWvmFD+CxWd0Hs6Qcb/YDnMyJW14aioXN4g==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.17.5.tgz",
+      "integrity": "sha512-Z4eo+rZJr1086wZWycBiIG/n7gGvVoqn28I7ZicS8xedRYu/4yp2loHgLn4NpxG3e46+dNWs4La6vinod+UydQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3738,9 +3782,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.17.3.tgz",
-      "integrity": "sha512-gcsCz8g0qY94C8RXiAlUH/89n84Q9RSptP91XrvnLOT+Xva9Aibd7ywd5k9ameuf8Nagyl0ezB1MInZ30S9SRw==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.17.5.tgz",
+      "integrity": "sha512-GNQqST7zI85dAFVyao6oiTeg5rNhO9FH1ZAd397qQhvwfxrrniNfuoewu8gPXyP0R4XBiiaCwhBL7w9S/F5guw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4321,9 +4365,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -4333,9 +4377,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -4424,9 +4468,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4442,25 +4486,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4532,9 +4564,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -5834,24 +5866,24 @@
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.8.11.tgz",
-      "integrity": "sha512-Ywm7W4z/lvSqGxmCxnP8p9wBJXm6SSsg9/sV5nslMlkAGUiKFCvWf/uU06Wig+MdARVnnx7rMR/yxFe73qF7VA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.8.12.tgz",
+      "integrity": "sha512-fiSf9Df4RqdKiL1WtS7eCqAWqDnLNwMZ9qU7ZMjXSAhI3wOLzycFflpVx7PWOxSoTJPtc61hwD5lkEpNoHezkg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.8.11",
+        "@module-federation/sdk": "0.8.12",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
     },
     "node_modules/@module-federation/data-prefetch": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.8.11.tgz",
-      "integrity": "sha512-Jq6lz2qfWrqGZQXWSXuOnRqq38lYdnzghoRn0extaVxmqCQHipILW79QRccK03rT2DSjttG6DNT50DT0z8URWw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.8.12.tgz",
+      "integrity": "sha512-YjCk6KPBQ4Ml2/2aIKQt11I4jBKOTvK3xHyAQMKPpX5aBbMEwonDhkpTitygUw3SMBdi3CP1KMRDJ3suj3O6Mg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.8.11",
-        "@module-federation/sdk": "0.8.11",
+        "@module-federation/runtime": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
         "fs-extra": "9.1.0"
       },
       "peerDependencies": {
@@ -5860,15 +5892,15 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.8.11.tgz",
-      "integrity": "sha512-mNcIGO9vz0PuIc2E8Q5oEBim2c4O7lAIZBdfDMaEGsI/Q6CTGH5ITCLb4clpc53oQIsjAVIo/ZrtmmRg4/sF/g==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.8.12.tgz",
+      "integrity": "sha512-BhRZsG68XtGzKM0N02/3ldiW+PTc+QaHCMNyiZnk3GcxS0qe6USu7fTQwRIPCC2GONIdoHD+GVYPN/NJWjbTFg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.8.11",
-        "@module-federation/managers": "0.8.11",
-        "@module-federation/sdk": "0.8.11",
-        "@module-federation/third-party-dts-extractor": "0.8.11",
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
+        "@module-federation/third-party-dts-extractor": "0.8.12",
         "adm-zip": "^0.5.10",
         "ansi-colors": "^4.1.3",
         "axios": "^1.7.4",
@@ -5933,21 +5965,21 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.8.11.tgz",
-      "integrity": "sha512-fjnW0j2suGr2AvR6YxjL6CJKj0zghmHcgxbzCkQDG4DkxVnNr86JoPOyfoWwa/7juX5HudlXitalBfo7bupYgA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.8.12.tgz",
+      "integrity": "sha512-uJODfWqL3C87LUu1E0ZLPRqE0sUt6QFH97bMFoCWYhkf8JS7J+wMc4KSc31ApaJs7CeQICXR1CYBAZDSdxkrOQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.8.11",
-        "@module-federation/data-prefetch": "0.8.11",
-        "@module-federation/dts-plugin": "0.8.11",
-        "@module-federation/error-codes": "0.8.11",
-        "@module-federation/inject-external-runtime-core-plugin": "0.8.11",
-        "@module-federation/managers": "0.8.11",
-        "@module-federation/manifest": "0.8.11",
-        "@module-federation/rspack": "0.8.11",
-        "@module-federation/runtime-tools": "0.8.11",
-        "@module-federation/sdk": "0.8.11",
+        "@module-federation/bridge-react-webpack-plugin": "0.8.12",
+        "@module-federation/data-prefetch": "0.8.12",
+        "@module-federation/dts-plugin": "0.8.12",
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/inject-external-runtime-core-plugin": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/manifest": "0.8.12",
+        "@module-federation/rspack": "0.8.12",
+        "@module-federation/runtime-tools": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
         "btoa": "^1.2.1",
         "upath": "2.0.1"
       },
@@ -5969,40 +6001,40 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.11.tgz",
-      "integrity": "sha512-mqt8/BQq11Cc/zbuHtojTwbZ78LJiy4f/cm9UsQPWf65Pqxi4Ticn40wccVFq8O9gee/QEi2Mf3XiwSf2SHl0A==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.12.tgz",
+      "integrity": "sha512-K+F4iiV62KY+IpjK6ggn3vI5Yt/T/LUb6xuazY78bhAGwLaHe1DYr7BfSutKMpiB+Dcs6U4dYOBogSMnnl0j4Q==",
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.8.11.tgz",
-      "integrity": "sha512-sezMsApV9Ccvwbe5wZlZ1iNTpbns68lLHHsATjDzUsnfbnY5wT/CrYcDi/vb61gELG02JnHiUiFR/8r/alKVxQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.8.12.tgz",
+      "integrity": "sha512-/vFW+eiBiqXOKkDYVKl5JXGI0H4Whj10P8JadowxuHcEuR+R7kkXXauYuGYKaxIFqG4zbN3r9su2qxIEEqOsOw==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "0.8.11"
+        "@module-federation/runtime-tools": "0.8.12"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.8.11.tgz",
-      "integrity": "sha512-5fncfxzrb450W3jTWxnOFNiIx2ReT+jhDPMUmJCKoGFa1etpbVw+TVp2l+HgR3tG1sxOt3tdJNjm9Spko8IxLQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.8.12.tgz",
+      "integrity": "sha512-+BBdBMptHiiT2ZsfPovQuHYkse6R1+dmDS6bAinw3UGpb418W8ERp5I4jHeyhEtr3t3mb/dh4sAsYM14/EWJ9Q==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.8.11",
+        "@module-federation/sdk": "0.8.12",
         "find-pkg": "2.0.0",
         "fs-extra": "9.1.0"
       }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.8.11.tgz",
-      "integrity": "sha512-3yR+ViwltDI9gfHjRl+IdDGMms2/e/4TyOdQUaC10haZqzcbxNEY52U5wB9PpegtgF5YqjnMgzdZpUeJfxjsHA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.8.12.tgz",
+      "integrity": "sha512-UwC6/QK37x7Xr5K+89iKxOy/uQHqFMd49axOhgDmFSrWQOULFQd51EpTOxFXgwZfiq/h0uVBYq/c0GB3Tdu8GA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "0.8.11",
-        "@module-federation/managers": "0.8.11",
-        "@module-federation/sdk": "0.8.11",
+        "@module-federation/dts-plugin": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/sdk": "0.8.12",
         "chalk": "3.0.0",
         "find-pkg": "2.0.0"
       }
@@ -6048,15 +6080,15 @@
       }
     },
     "node_modules/@module-federation/node": {
-      "version": "2.6.24",
-      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.6.24.tgz",
-      "integrity": "sha512-8jN8COzeyLsdEQr9qwtCK15mosbMEX77CcJmybe46aMDdKrfmjJjeKWnJZkxfr6RwC6/CDscjQM9tXA18TAqDA==",
+      "version": "2.6.27",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.6.27.tgz",
+      "integrity": "sha512-vHxHuS6uDiVtvR7WK+bSas6f+c2Qb5ePotkV94QEmIwJSEPzQDiMyYWrA0CxMmPbMfYdBcyOOf4RBGqF0VKa4g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "0.8.11",
-        "@module-federation/runtime": "0.8.11",
-        "@module-federation/sdk": "0.8.11",
-        "@module-federation/utilities": "3.1.42",
+        "@module-federation/enhanced": "0.9.1",
+        "@module-federation/runtime": "0.9.1",
+        "@module-federation/sdk": "0.9.1",
+        "@module-federation/utilities": "3.1.45",
         "btoa": "1.2.1",
         "encoding": "^0.1.13",
         "node-fetch": "2.7.0"
@@ -6078,19 +6110,373 @@
         }
       }
     },
-    "node_modules/@module-federation/rspack": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.8.11.tgz",
-      "integrity": "sha512-z5xHETXGNqYEGbRT4HWAA7zb6qZ7zd6sVDTCbvSiDJ6pST78Yrkz3B6vbMhgh37LrhXbULudIo/fe0z/v/EWdA==",
+    "node_modules/@module-federation/node/node_modules/@module-federation/bridge-react-webpack-plugin": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-0.9.1.tgz",
+      "integrity": "sha512-znN/Qm6M0U1t3iF10gu1hSxDkk18yz78yvk+AMB34UDzpXHiC1zbpIeV2CQNV5GCeafmCICmcn9y1qh7F54KTg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "0.8.11",
-        "@module-federation/dts-plugin": "0.8.11",
-        "@module-federation/inject-external-runtime-core-plugin": "0.8.11",
-        "@module-federation/managers": "0.8.11",
-        "@module-federation/manifest": "0.8.11",
-        "@module-federation/runtime-tools": "0.8.11",
-        "@module-federation/sdk": "0.8.11"
+        "@module-federation/sdk": "0.9.1",
+        "@types/semver": "7.5.8",
+        "semver": "7.6.3"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/data-prefetch": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/data-prefetch/-/data-prefetch-0.9.1.tgz",
+      "integrity": "sha512-rS1AsgRvIMAWK8oMprEBF0YQ3WvsqnumjinvAZU1Dqut5DICmpQMTPEO1OrAKyjO+PQgEhmq13HggzN6ebGLrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.9.1",
+        "@module-federation/sdk": "0.9.1",
+        "fs-extra": "9.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/dts-plugin": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-0.9.1.tgz",
+      "integrity": "sha512-DezBrFaIKfDcEY7UhqyO1WbYocERYsR/CDN8AV6OvMnRlQ8u0rgM8qBUJwx0s+K59f+CFQFKEN4C8p7naCiHrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.9.1",
+        "@module-federation/managers": "0.9.1",
+        "@module-federation/sdk": "0.9.1",
+        "@module-federation/third-party-dts-extractor": "0.9.1",
+        "adm-zip": "^0.5.10",
+        "ansi-colors": "^4.1.3",
+        "axios": "^1.7.4",
+        "chalk": "3.0.0",
+        "fs-extra": "9.1.0",
+        "isomorphic-ws": "5.0.0",
+        "koa": "2.15.4",
+        "lodash.clonedeepwith": "4.5.0",
+        "log4js": "6.9.1",
+        "node-schedule": "2.1.1",
+        "rambda": "^9.1.0",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/enhanced": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-0.9.1.tgz",
+      "integrity": "sha512-c9siKVjcgT2gtDdOTqEr+GaP2X/PWAS0OV424ljKLstFL1lcS/BIsxWFDmxPPl5hDByAH+1q4YhC1LWY4LNDQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.9.1",
+        "@module-federation/data-prefetch": "0.9.1",
+        "@module-federation/dts-plugin": "0.9.1",
+        "@module-federation/error-codes": "0.9.1",
+        "@module-federation/inject-external-runtime-core-plugin": "0.9.1",
+        "@module-federation/managers": "0.9.1",
+        "@module-federation/manifest": "0.9.1",
+        "@module-federation/rspack": "0.9.1",
+        "@module-federation/runtime-tools": "0.9.1",
+        "@module-federation/sdk": "0.9.1",
+        "btoa": "^1.2.1",
+        "upath": "2.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/error-codes": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.9.1.tgz",
+      "integrity": "sha512-q8spCvlwUzW42iX1irnlBTcwcZftRNHyGdlaoFO1z/fW4iphnBIfijzkigWQzOMhdPgzqN/up7XN+g5hjBGBtw==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/inject-external-runtime-core-plugin": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-0.9.1.tgz",
+      "integrity": "sha512-BPfzu1cqDU5BhM493enVF1VfxJWmruen0ktlHrWdJJlcddhZzyFBGaLAGoGc+83fS75aEllvJTEthw4kMViMQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@module-federation/runtime-tools": "0.9.1"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/managers": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-0.9.1.tgz",
+      "integrity": "sha512-8hpIrvGfiODxS1qelTd7eaLRVF7jrp17RWgeH1DWoprxELANxm5IVvqUryB+7j+BhoQzamog9DL5q4MuNfGgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/sdk": "0.9.1",
+        "find-pkg": "2.0.0",
+        "fs-extra": "9.1.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/manifest": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-0.9.1.tgz",
+      "integrity": "sha512-+GteKBXrAUkq49i2CSyWZXM4vYa+mEVXxR9Du71R55nXXxgbzAIoZj9gxjRunj9pcE8+YpAOyfHxLEdWngxWdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/dts-plugin": "0.9.1",
+        "@module-federation/managers": "0.9.1",
+        "@module-federation/sdk": "0.9.1",
+        "chalk": "3.0.0",
+        "find-pkg": "2.0.0"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/rspack": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.9.1.tgz",
+      "integrity": "sha512-ZJqG75dWHhyTMa9I0YPJEV2XRt0MFxnDiuMOpI92esdmwWY633CBKyNh1XxcLd629YVeTv03+whr+Fz/f91JEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.9.1",
+        "@module-federation/dts-plugin": "0.9.1",
+        "@module-federation/inject-external-runtime-core-plugin": "0.9.1",
+        "@module-federation/managers": "0.9.1",
+        "@module-federation/manifest": "0.9.1",
+        "@module-federation/runtime-tools": "0.9.1",
+        "@module-federation/sdk": "0.9.1"
+      },
+      "peerDependencies": {
+        "@rspack/core": ">=0.7",
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/runtime": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.9.1.tgz",
+      "integrity": "sha512-jp7K06weabM5BF5sruHr/VLyalO+cilvRDy7vdEBqq88O9mjc0RserD8J+AP4WTl3ZzU7/GRqwRsiwjjN913dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.9.1",
+        "@module-federation/runtime-core": "0.9.1",
+        "@module-federation/sdk": "0.9.1"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/runtime-core": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.9.1.tgz",
+      "integrity": "sha512-r61ufhKt5pjl81v7TkmhzeIoSPOaNtLynW6+aCy3KZMa3RfRevFxmygJqv4Nug1L0NhqUeWtdLejh4VIglNy5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.9.1",
+        "@module-federation/sdk": "0.9.1"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/runtime-tools": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.9.1.tgz",
+      "integrity": "sha512-JQZ//ab+lEXoU2DHAH+JtYASGzxEjXB0s4rU+6VJXc8c+oUPxH3kWIwzjdncg2mcWBmC1140DCk+K+kDfOZ5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.9.1",
+        "@module-federation/webpack-bundler-runtime": "0.9.1"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/sdk": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.1.tgz",
+      "integrity": "sha512-YQonPTImgnCqZjE/A+3N2g3J5ypR6kx1tbBzc9toUANKr/dw/S63qlh/zHKzWQzxjjNNVMdXRtTMp07g3kgEWg==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/third-party-dts-extractor": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.9.1.tgz",
+      "integrity": "sha512-KeIByP718hHyq+Mc53enZ419pZZ1fh9Ns6+/bYLkc3iCoJr/EDBeiLzkbMwh2AS4Qk57WW0yNC82xzf7r0Zrrw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-pkg": "2.0.0",
+        "fs-extra": "9.1.0",
+        "resolve": "1.22.8"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.9.1.tgz",
+      "integrity": "sha512-CxySX01gT8cBowKl9xZh+voiHvThMZ471icasWnlDIZb14KasZoX1eCh9wpGvwoOdIk9rIRT7h70UvW9nmop6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.9.1",
+        "@module-federation/sdk": "0.9.1"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/koa": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
+      "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@module-federation/node/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@module-federation/rspack": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-0.8.12.tgz",
+      "integrity": "sha512-G73Cq7VwKdpFZwMd9hEBsE2HLF7mNQEIvLSiW6HOZG/+iWRRED1opiVkrjOmkcg770rChYSqTBiLvUS7HDT5Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/bridge-react-webpack-plugin": "0.8.12",
+        "@module-federation/dts-plugin": "0.8.12",
+        "@module-federation/inject-external-runtime-core-plugin": "0.8.12",
+        "@module-federation/managers": "0.8.12",
+        "@module-federation/manifest": "0.8.12",
+        "@module-federation/runtime-tools": "0.8.12",
+        "@module-federation/sdk": "0.8.12"
       },
       "peerDependencies": {
         "@rspack/core": ">=0.7",
@@ -6107,49 +6493,49 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.11.tgz",
-      "integrity": "sha512-07aBwU5AJltbspOot0gVYDA0PAMNkjBBaIRIUMsLNj9MGx01/YKl13z239UdC0Fk4hFlexpkef8ZvnMPgp4YFA==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.12.tgz",
+      "integrity": "sha512-eYohRfambj/qzxz6tEakDn459ROcixWO4zL5gmTEOmwG+jCDnxGR14j1guopyrrpjb6EKFNrPVWtYZTPPfGdQQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.8.11",
-        "@module-federation/runtime-core": "0.6.19",
-        "@module-federation/sdk": "0.8.11"
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/runtime-core": "0.6.20",
+        "@module-federation/sdk": "0.8.12"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.19.tgz",
-      "integrity": "sha512-PDMQIkxEWlF9c1ezDl1f+DwzoNoWan/jfhtBoOjp0JiMtPNPe3ZUH0v2++Cbaxc/BRtHT+ILCSDEezC4zF98uw==",
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.6.20.tgz",
+      "integrity": "sha512-rX7sd/i7tpkAbfMD4TtFt/57SWNC/iv7UYS8g+ad7mnCJggWE1YEKsKSFgcvp4zU3thwR+j2y+kOCwd1sQvxEA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.8.11",
-        "@module-federation/sdk": "0.8.11"
+        "@module-federation/error-codes": "0.8.12",
+        "@module-federation/sdk": "0.8.12"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.11.tgz",
-      "integrity": "sha512-whomac5Hd4+fuUhgT+f0eAino5OwhDSowkXmJocZkdEZfudYD1qWH1qc5DQeEZ69zsrsb7q8S8M0d8Q+7bsVzQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.12.tgz",
+      "integrity": "sha512-H97wR/toSU9+UO9S0VHLmPg/7QgohMI52EZlR0Kh0F4PD6fbiWuO4kBIp7R6g0dMI9D4NVKWTKV8xA9ASU+k7g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.8.11",
-        "@module-federation/webpack-bundler-runtime": "0.8.11"
+        "@module-federation/runtime": "0.8.12",
+        "@module-federation/webpack-bundler-runtime": "0.8.12"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.11.tgz",
-      "integrity": "sha512-h9oXuOABJ5O77TeWZoLO3KNq7HywdZkX2c2rmYEQRRrkuXHgHAQu0nEs7ZuL5YDWNQLUMxoOyTH+sK+JWgvnKQ==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.12.tgz",
+      "integrity": "sha512-zFgXYBHbzwIqlrLfn6ewIRXDZCctDDQT2nFhbsZr29yWQgpmW1fm2kJCxQsG0DENGGN1KpzfDoxjjvSKJS/ZHA==",
       "license": "MIT",
       "dependencies": {
         "isomorphic-rslog": "0.0.7"
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.8.11.tgz",
-      "integrity": "sha512-X1esz2m836hp/eKH230AerMKITVlNfeNeaSyNX3+YPqOK8EkdMSCKkf/K5zYuqdY0ypNJNYkWPIx8uYFOfYe5Q==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-0.8.12.tgz",
+      "integrity": "sha512-+ZO5XpBwEhP9v/Tqk51YgswwbAzj4TXKZ54++uVDsLnOh9yydVGJ/b5pQcSrc8B1C55+498tsDEcNsFgZODgMQ==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -6175,12 +6561,12 @@
       }
     },
     "node_modules/@module-federation/utilities": {
-      "version": "3.1.42",
-      "resolved": "https://registry.npmjs.org/@module-federation/utilities/-/utilities-3.1.42.tgz",
-      "integrity": "sha512-TdBJj2YUMXxS3exuYuB3syOCXNm8I4y5hstmm9XgjEYgUANX9kElBisLYXIPtdGwSvBWAEFvXPE24nvVNG9OtA==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@module-federation/utilities/-/utilities-3.1.45.tgz",
+      "integrity": "sha512-qbMxtvj96SAxir0Y0z/+Bbv+N6MpkKiqLzDbfh+npmQCSUbWEbNjAHuClxhFwM1NMOKh+NlSO+EhU80AbuXeTw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "0.8.11"
+        "@module-federation/sdk": "0.9.1"
       },
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
@@ -6199,14 +6585,20 @@
         }
       }
     },
+    "node_modules/@module-federation/utilities/node_modules/@module-federation/sdk": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.9.1.tgz",
+      "integrity": "sha512-YQonPTImgnCqZjE/A+3N2g3J5ypR6kx1tbBzc9toUANKr/dw/S63qlh/zHKzWQzxjjNNVMdXRtTMp07g3kgEWg==",
+      "license": "MIT"
+    },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.11.tgz",
-      "integrity": "sha512-lbQyJjWZrg+90v9BJSMay5EIqnl/NrJGteR9eqeN1P0YLfXVq46gN1qqdaP6aHMnPbSU3PlFTNO/dgJzciLGTg==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.12.tgz",
+      "integrity": "sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.8.11",
-        "@module-federation/sdk": "0.8.11"
+        "@module-federation/runtime": "0.8.12",
+        "@module-federation/sdk": "0.8.12"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -6587,9 +6979,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.0.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.9.tgz",
-      "integrity": "sha512-+SKMYQE7O55tJGQVibnAlR9sXRBCF/8gM1cILdLT7cLj7+51NYD7eAHuAcGYiQIyXsTehZoO7C+B7S3ibNi3aw==",
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.10.tgz",
+      "integrity": "sha512-pzGXp14KF2Q4CDZGQgPK4l8zEg7i6cNkb+10yc8ZA5K41cLe3ZbWW1YxtY2e/glHauOJwTLSVjH4tiRVtOTizg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -6616,9 +7008,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.0.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.0.9.tgz",
-      "integrity": "sha512-w32ZF1acSnidiRERGRC/Ki7eSrnTdP7twRnjy15Qnmij3oYRCdgX5aZvbUNv17A7bn9S22p+wMNcpHxqwUiOsQ==",
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.0.10.tgz",
+      "integrity": "sha512-f0qB8ztNWZeAD4E4fUdHConmNYCa/A78U7WJu5mX9OLYfOAs3ESYCDfsH9MRUvkA4Ft4Y1uMmyJo5L4fg4+beg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6657,9 +7049,9 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.0.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.9.tgz",
-      "integrity": "sha512-AX3UbVNkK+yB0lxfwjy5krxLZy/bWD2V+3WIbc0btRQVcxGj4LWL0yenbAo0jiAFwW3rKt7SbmMHUuKK6OH5qA==",
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.10.tgz",
+      "integrity": "sha512-UVSf0yaWFBC2Zn2FOWABXxCnyG8XNIXrNnvTFpbUFqaJu1YDdwJ7wQBBqxq9CtJT7ILqSmfhOU7HS0d/0EAxpw==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
@@ -7051,14 +7443,14 @@
       }
     },
     "node_modules/@nestjs/schematics": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.0.tgz",
-      "integrity": "sha512-wts8lG0GfNWw3Wk9aaG5I/wcMIAdm7HjjeThQfUZhJxeIFT82Z3F5+0cYdHH4ii2pYQGiCSrR1VcuMwPiHoecg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.1.tgz",
+      "integrity": "sha512-PHPAUk4sXkfCxiMacD1JFC+vEyzXjZJRCu1KT2MmG2hrTiMDMk5KtMprro148JUefNuWbVyN0uLTJVSmWVzhoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.1",
-        "@angular-devkit/schematics": "19.0.1",
+        "@angular-devkit/core": "19.1.7",
+        "@angular-devkit/schematics": "19.1.7",
         "comment-json": "4.2.5",
         "jsonc-parser": "3.3.1",
         "pluralize": "8.0.0"
@@ -7068,9 +7460,9 @@
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.0.1.tgz",
-      "integrity": "sha512-oXIAV3hXqUW3Pmm95pvEmb+24n1cKQG62FzhQSjOIrMeHiCbGLNuc8zHosIi2oMrcCJJxR6KzWjThvbuzDwWlw==",
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.1.7.tgz",
+      "integrity": "sha512-q0I6L9KTqyQ7D5M8H+fWLT+yjapvMNb7SRdfU6GzmexO66Dpo83q4HDzuDKIPDF29Yl0ELs9ICJqe9yUXh6yDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7096,15 +7488,15 @@
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.0.1.tgz",
-      "integrity": "sha512-N9dV8WpNRULykNj8fSxQrta85gPKxb315J3xugLS2uwiFWhz7wo5EY1YeYhoVKoVcNB2ng9imJgC5aO52AHZwg==",
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.1.7.tgz",
+      "integrity": "sha512-AP6FvhMybCYs3gs+vzEAzSU1K//AFT3SVTRFv+C3WMO5dLeAHeGzM8I2dxD5EHQQtqIE/8apP6CxGrnpA5YlFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.0.1",
+        "@angular-devkit/core": "19.1.7",
         "jsonc-parser": "3.3.1",
-        "magic-string": "0.30.12",
+        "magic-string": "0.30.17",
         "ora": "5.4.1",
         "rxjs": "7.8.1"
       },
@@ -7114,20 +7506,20 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/magic-string": {
-      "version": "0.30.12",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
-      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+    "node_modules/@nestjs/schematics/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "11.0.9",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.0.9.tgz",
-      "integrity": "sha512-49UV5tC4N0pLf6waVjBVr/CyTkQPGZG/wLmbmu1INd/brprKOJ2lT3nl+6qfWJIqGbxGqZHUQr5FcDk+T/w9lQ==",
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.0.10.tgz",
+      "integrity": "sha512-uZcdnvmHXWnvozYOAwZi1elpRRfqIfYqHglCavjhjcj3cH1MVZkwoTqntW3XOPQlT4lf96InjP1exGaW4B9wUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7161,9 +7553,9 @@
       "optional": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.1.7.tgz",
-      "integrity": "sha512-U39LVqHWj+GtKzBA3+AseHZgLPlL5YE/iRkZJ4PHQVrgW9LtyMzPuUmnW+e0XQwPFHq9xQxaoj3w8gApj4/MIg==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-19.1.8.tgz",
+      "integrity": "sha512-uaEQMX0qElCO27R55efEQ/5UjID5KPLtgjwF9VXJ9Eoqsnr7gvKbTBQLtI8uui9aDJRxyvs58SC46E4x2EaAhQ==",
       "license": "MIT",
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
@@ -7263,9 +7655,9 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.1.tgz",
-      "integrity": "sha512-BBWMMxeQzalmKadyimwb2/VVQyJB01PH0HhVSNLHNBDZN/M/h/02P6f8fxedIiFhpMj11SO9Ep5tKTBE7zL2nw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-6.0.3.tgz",
+      "integrity": "sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7274,7 +7666,6 @@
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^10.0.0",
         "proc-log": "^5.0.0",
-        "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^5.0.0"
@@ -8180,6 +8571,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/@nx/nest/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@nx/node": {
@@ -9518,26 +9919,26 @@
       ]
     },
     "node_modules/@rspack/binding": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.3.tgz",
-      "integrity": "sha512-enpOXZPQOJO800wdWcR7H5Dx5UZfwkaT0D0xsHD53WbpI09Z2KJbLX7I/i1FLLy3K1KQTB+2FIHLVdRikasXZA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.6.tgz",
+      "integrity": "sha512-Szu9w+RktSunBNfIHDORY/YRLFplhnUF9QgpUles8XYzKo6NA96WQNJoFbrBDkEQPbNUtVpEk4Ua1c9ZWtVTJQ==",
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.2.3",
-        "@rspack/binding-darwin-x64": "1.2.3",
-        "@rspack/binding-linux-arm64-gnu": "1.2.3",
-        "@rspack/binding-linux-arm64-musl": "1.2.3",
-        "@rspack/binding-linux-x64-gnu": "1.2.3",
-        "@rspack/binding-linux-x64-musl": "1.2.3",
-        "@rspack/binding-win32-arm64-msvc": "1.2.3",
-        "@rspack/binding-win32-ia32-msvc": "1.2.3",
-        "@rspack/binding-win32-x64-msvc": "1.2.3"
+        "@rspack/binding-darwin-arm64": "1.2.6",
+        "@rspack/binding-darwin-x64": "1.2.6",
+        "@rspack/binding-linux-arm64-gnu": "1.2.6",
+        "@rspack/binding-linux-arm64-musl": "1.2.6",
+        "@rspack/binding-linux-x64-gnu": "1.2.6",
+        "@rspack/binding-linux-x64-musl": "1.2.6",
+        "@rspack/binding-win32-arm64-msvc": "1.2.6",
+        "@rspack/binding-win32-ia32-msvc": "1.2.6",
+        "@rspack/binding-win32-x64-msvc": "1.2.6"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-xuwYzhPgNCr4BtKXCU3xe4249TFsXAZglIlbxv8Qs3PeIarrZMRddcqH2zUXi+nJavNw3yN12sCYEzk1f+O4FQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-31URF3tAgVR8Pt6Oc8MANV/gYNR6DlUhtIMmWM2EwdcWTyIEnN7gSDdjtB6cYvETHwdM7NDSCOgyIirG1+tNZw==",
       "cpu": [
         "arm64"
       ],
@@ -9548,9 +9949,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-afiIN8elcrO2EtO27UN0qyZqu5FXGUdclud56DrhvEfnWS3GGxJEdjA8XUYVXkfCYakdXHucIJKlkkgaAjEvHg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-0XJMOGEqERP9N8zgJxfdWzuZG9buEp6RL4PSVaXPvcKw75Ig3YW50A8sMqd4SNXAqJp2gC706d6l8OnMXpRo3w==",
       "cpu": [
         "x64"
       ],
@@ -9561,9 +9962,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-      "integrity": "sha512-K2u/fPUmKujlKSWL3q2zaUu8/6ZK/bOGKcqJSib8jdanQQ/GFKwKtPAFOOa/vvqbzhDocqKOobFR10FhgJqCHg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-Ld26wvy9NSTqhUb/ll5ZpIW08ZzUkTl5daW3xHJgcaoRDrnJkRV1pMx8cdV8S+xsavJIPf4c+BuKpU6Ml2kx9A==",
       "cpu": [
         "arm64"
       ],
@@ -9574,9 +9975,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-      "integrity": "sha512-mgovdzGb6cH9hQsjTyzDbfZWCPhTcoHcLro1P7UbiqcLPMDJp/k3Io9xV2/EJhaDA1aynIdq7XfY0fuk4+6Irw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-TrklgPKngiuzRovr7MdXDKXPfjJlT3g5LmCX/Y4pPfNrrOLjzL/fpEBRXBJEhrSuNWqpkZSNLs+Av02IY7manQ==",
       "cpu": [
         "arm64"
       ],
@@ -9587,9 +9988,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-      "integrity": "sha512-542lwJzB1RMGuVdBdA3cOWTlmL9okpOppHUBWcNCjmJM+9zTI+0jwjVe8HaqOqtuR8XzNsoCwT9QonU/GLcuhg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-aZ6mrZyuUg8hlBf7qEfXRAVPh2tM8E7kYZhI5eBOUoi6XhO5fTVcf/S2VUimFWLUmJdmSujG+nrYGQu1n74Xag==",
       "cpu": [
         "x64"
       ],
@@ -9600,9 +10001,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-      "integrity": "sha512-dJromiREDcTWqzfCOI5y1IVoYmUnCv7vCp63AEq0+13fJJdk7+pcNN3VV2jOKpk9VECSvjg1c01wl+UzXAXFMw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-Trg+s1b6sD4XNMOvwWwI+cebwGOBEXsND9Ofjc6L1RPtCeZQ5Rrycfh/HVymI50Y48g8YMibLZw8G2gAfK8SZw==",
       "cpu": [
         "x64"
       ],
@@ -9613,9 +10014,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-      "integrity": "sha512-S8ZKddMMQDGy8jx/R0i2m1XrmfY2CpI+t6lIEpsuZuKUR4MbOGKN2DuL4MDnT3m8JaYvC8ihsvQjBXQCy3SNxQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-lEWMW8H5ERYX376NA2qGritCHmcMNW+Ob6WVWuEZNh0oWeBD/mWqWFxbCx5J3KtlVy4miwk65V8YDd92alUEyw==",
       "cpu": [
         "arm64"
       ],
@@ -9626,9 +10027,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.3.tgz",
-      "integrity": "sha512-74lqSMKQJcJcgfFaxm+G9YVJSl2KK9/v4fRoMsWApztNy2qNgee+UguNBCOU6JLa3rVSj8Z5OVVDtJkGFrSvVg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.6.tgz",
+      "integrity": "sha512-ML3f7vDyv2c7d+ync6l3aRY4cIAKUPT5n+yz7sRcwIBrB4n1n4rH6wf5a56h4wHjiWpnV0gXBXI9SrYD5a4vRQ==",
       "cpu": [
         "ia32"
       ],
@@ -9639,9 +10040,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-      "integrity": "sha512-fcU532PgFdd5Bil8jwQW0Dcb/80oM6V0qSstGIxZ4M77t4t8e/PcukXfORTL71FfNQ64Rd4Dp6XRl1NHNJVxeg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-0W0iComo7cdOg5fOuaZ2l1Mz7DG1A4SPDes557n9CH2Tf5rub3m2rBoMQ1B/XIkcUeGf+oB6bbBBroHPH0vQBA==",
       "cpu": [
         "x64"
       ],
@@ -9652,15 +10053,15 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.3.tgz",
-      "integrity": "sha512-BFgdUYf05/hjjY9Nlwq8DpWaRJN5w2kTl8ZJi20SRL60oAx+ZD2ABT+fsPhBiFSmfTZDdvGGIq5e3vfRzoIuqg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-CYiz6kXWdZX0tKu819Bromg84W9+GrgSY7OTMtr39IKRcCHjdVVjPYFthga2bNppfT+Ifeti5Ed06Xxlptr9CQ==",
       "license": "MIT",
       "dependencies": {
         "@module-federation/runtime-tools": "0.8.4",
-        "@rspack/binding": "1.2.3",
+        "@rspack/binding": "1.2.6",
         "@rspack/lite-tapable": "1.0.1",
-        "caniuse-lite": "^1.0.30001616"
+        "caniuse-lite": "^1.0.30001700"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -9742,13 +10143,13 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "19.1.7",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.1.7.tgz",
-      "integrity": "sha512-BB8yMGmYDZzSb8Nu+Ln0TKyeoS3++f9STCYw30NwM3IViHxJJYxu/zowzwSa9TjftIzdCpbOaPxGS0vU9UOUDQ==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-19.1.8.tgz",
+      "integrity": "sha512-ytgClbMPn+i+w1S3QukR/Vdge+sfU9aX49ao+XRwoWdOssHUjmVjQcCEdzu0ucSrNPZnhm34bdDPzADLhln60w==",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.1.7",
-        "@angular-devkit/schematics": "19.1.7",
+        "@angular-devkit/core": "19.1.8",
+        "@angular-devkit/schematics": "19.1.8",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -9758,30 +10159,30 @@
       }
     },
     "node_modules/@secretlint/config-creator": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-9.0.0.tgz",
-      "integrity": "sha512-w92my2FP4gSOT+782+D46yk5SzVZ835ZMb6lxcNc4inVY/iNy8YKpKBAkwPnH/PkXqqwB5mVGCBZx+4TIN/ksQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-9.2.0.tgz",
+      "integrity": "sha512-gSLYpsDfafNvUTscfG6k7+ZcfgCteX3y9F+ikgpoj0KSRhLTmZx6DHb9Xx+fVo6dsXq0iOaptLm98cmN/mOHtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/types": "^9.0.0"
+        "@secretlint/types": "^9.2.0"
       },
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@secretlint/config-loader": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-9.0.0.tgz",
-      "integrity": "sha512-r6u2nmXfSPyMkJsHsxTpCIhmVIA0CUKIAEdVGpeb9ZPB1Whkr6/r2d96wEJO/1m58IUVXbR3baJgUkyd8fdQqg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-9.2.0.tgz",
+      "integrity": "sha512-V4AI7rSJ8kgxx+skMfwSACiM6TlBSIP3bc4xvdIim/xaTWN2/S3jucUQDJM/65hbjReY/wXoRDnwxZN4j/Ixpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/profiler": "^9.0.0",
-        "@secretlint/resolver": "^9.0.0",
-        "@secretlint/types": "^9.0.0",
+        "@secretlint/profiler": "^9.2.0",
+        "@secretlint/resolver": "^9.2.0",
+        "@secretlint/types": "^9.2.0",
         "ajv": "^8.17.1",
-        "debug": "^4.3.7",
+        "debug": "^4.4.0",
         "rc-config-loader": "^4.1.3",
         "try-resolve": "^1.0.1"
       },
@@ -9790,15 +10191,15 @@
       }
     },
     "node_modules/@secretlint/core": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-9.0.0.tgz",
-      "integrity": "sha512-+ICPisxcaytrdqSh7Fkyyh9fQE2/DiUNutnWnSeC5gOoaowGwIrKt9D1pHePfLhGfBTq+ipOS6uJxmLKJ0hbJw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-9.2.0.tgz",
+      "integrity": "sha512-sNpEXmtalQsKh5I1ihljuahmVq61ssh1Ll4CqHtgzMynTI3DwvzASjSRZhZAuvRV4HNKM3ooPxkiCVQeHb97ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/profiler": "^9.0.0",
-        "@secretlint/types": "^9.0.0",
-        "debug": "^4.3.7",
+        "@secretlint/profiler": "^9.2.0",
+        "@secretlint/types": "^9.2.0",
+        "debug": "^4.4.0",
         "structured-source": "^4.0.0"
       },
       "engines": {
@@ -9806,22 +10207,22 @@
       }
     },
     "node_modules/@secretlint/formatter": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-9.0.0.tgz",
-      "integrity": "sha512-/VT9D63FE0Uon7roV/9XWbQkylDr5NjiAuAabN1VnjhxAyM/Me1t9AN6oYzXMooo07ahUQTYdTu7+K4kD18QyQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-9.2.0.tgz",
+      "integrity": "sha512-jy5m0OfKtzfKC7V5TbWpB0DMm7oEgweLIzich4xQuAaRHhKt+P5tZ9jnPvj4ljqaMGB7sOa+1ViBf3r/V30ajA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/resolver": "^9.0.0",
-        "@secretlint/types": "^9.0.0",
-        "@textlint/linter-formatter": "^14.2.1",
-        "@textlint/module-interop": "^14.2.1",
-        "@textlint/types": "^14.2.1",
+        "@secretlint/resolver": "^9.2.0",
+        "@secretlint/types": "^9.2.0",
+        "@textlint/linter-formatter": "^14.4.2",
+        "@textlint/module-interop": "^14.4.2",
+        "@textlint/types": "^14.4.2",
         "chalk": "^4.1.2",
-        "debug": "^4.3.7",
+        "debug": "^4.4.0",
         "pluralize": "^8.0.0",
         "strip-ansi": "^6.0.1",
-        "table": "^6.8.2",
+        "table": "^6.9.0",
         "terminal-link": "^2.1.1",
         "try-resolve": "^1.0.1"
       },
@@ -9876,19 +10277,19 @@
       }
     },
     "node_modules/@secretlint/node": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-9.0.0.tgz",
-      "integrity": "sha512-tXuxdirxfG68i4+n+0QV4hokCD13+S7hDPCJ4TqIlWk9MeDysc1x/dfcmTrRKsRUKL44Ib2pHk/hrl4g28/h9g==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-9.2.0.tgz",
+      "integrity": "sha512-xh240gHq+kArWiEP2yn8OzouWkk4BuxuCMMtHuyzViqDmcvI00YEatOAPby1o6M/14beF+9yvGH/3VKQr/1xPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/config-loader": "^9.0.0",
-        "@secretlint/core": "^9.0.0",
-        "@secretlint/formatter": "^9.0.0",
-        "@secretlint/profiler": "^9.0.0",
-        "@secretlint/source-creator": "^9.0.0",
-        "@secretlint/types": "^9.0.0",
-        "debug": "^4.3.7",
+        "@secretlint/config-loader": "^9.2.0",
+        "@secretlint/core": "^9.2.0",
+        "@secretlint/formatter": "^9.2.0",
+        "@secretlint/profiler": "^9.2.0",
+        "@secretlint/source-creator": "^9.2.0",
+        "@secretlint/types": "^9.2.0",
+        "debug": "^4.4.0",
         "p-map": "^4.0.0"
       },
       "engines": {
@@ -9912,23 +10313,23 @@
       }
     },
     "node_modules/@secretlint/profiler": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-9.0.0.tgz",
-      "integrity": "sha512-IJBvFMGHsRAFGNa6FevNXRmA8LMNWB77lW+8VMaGNjECPhARPXu7JetfsNkTQEuKnR+Vg0r3OT9vVhmo2wowPw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-9.2.0.tgz",
+      "integrity": "sha512-6DZsNSSqq+EArnZ4OV0t1ivdBdZzFaPp2ATkHQyHRbU+LV2k/iR1br6cdMoFbXTqqbtaq3Mt6jGT0j+K43ZgNA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@secretlint/resolver": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-9.0.0.tgz",
-      "integrity": "sha512-Qg1pGwBRtNUi6CTOCceivikNCPq8tRtLhxOrH+powmopHwe77IU2N3U4JaQ0aeq636pwZZgLluePVzMqkku39Q==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-9.2.0.tgz",
+      "integrity": "sha512-MDDBea3mVXuV8mxshl+sBopjRKALvOGwM44eizpL6PGJs76upIF+S2+MmTV8331peu03JDUtxkjni9jShnQK/g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@secretlint/secretlint-rule-preset-recommend": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-9.0.0.tgz",
-      "integrity": "sha512-EWw2bnjZUTJ5krtSANW7AhmKam0wh/clSlrTIYpkmjwNbUHj1v9rjRqCi2V0VxktiMwkCmtqW+kX+b2EP1LrIA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-9.2.0.tgz",
+      "integrity": "sha512-Q9lCCdrbXd8L+RutpEuaOsudshy31E9tAlgpSc1T6t0xY/Z0PXzCV4ej4hzm7oh3bYyyALSexNYnW9B3nUYo4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9936,13 +10337,13 @@
       }
     },
     "node_modules/@secretlint/source-creator": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-9.0.0.tgz",
-      "integrity": "sha512-RFiU5iQlZ35ecyjk+1BTYjWH9AGUaXDa44lTl3fBqMAUFISTKvrfl//bttJrrgIVgLXFrjWMo9Ym4JgJmoNFkg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-9.2.0.tgz",
+      "integrity": "sha512-K1QuSFrtPy3QmY5tI1kZOB/3BlRxQzP2lgmP+zTAUhlmj+x4x/n76wR6+vb7UhnYHioWp64L2LB0gjFj7A8wOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/types": "^9.0.0",
+        "@secretlint/types": "^9.2.0",
         "istextorbinary": "^6.0.0"
       },
       "engines": {
@@ -9950,9 +10351,9 @@
       }
     },
     "node_modules/@secretlint/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-bpbtAvx99eubfhoNgGEzm8gu9UJPFUzPSLQSvXz8BVCeGq1yJpCIp3fExcDAl7v1DAd860B/5zqMxlk9X2cOnA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-9.2.0.tgz",
+      "integrity": "sha512-6nWGPSK1bVRosyfrwtHRxQE8cXuBBb/Gx2LR2Qoom+A67LbmCtrUWtPk2dmxHV1OiAcPEmY6OztpXOxHEhOEjw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10155,15 +10556,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.16.tgz",
-      "integrity": "sha512-nOINg/OUcZazCW7B55QV2/UB8QAqz9FYe4+z229+4RYboBTZ102K7ebOEjY5sKn59JgAkhjZTz+5BKmXpDFopw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-67+lBHZ1lAJQKoOhBHl9DE2iugPYAulRVArZjoF+DnIY3G9wLXCXxw5It0IaCnzvJVvUPxGmr0rHViXKBDP5Vg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.17"
+        "@swc/types": "^0.1.18"
       },
       "engines": {
         "node": ">=10"
@@ -10173,16 +10574,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.10.16",
-        "@swc/core-darwin-x64": "1.10.16",
-        "@swc/core-linux-arm-gnueabihf": "1.10.16",
-        "@swc/core-linux-arm64-gnu": "1.10.16",
-        "@swc/core-linux-arm64-musl": "1.10.16",
-        "@swc/core-linux-x64-gnu": "1.10.16",
-        "@swc/core-linux-x64-musl": "1.10.16",
-        "@swc/core-win32-arm64-msvc": "1.10.16",
-        "@swc/core-win32-ia32-msvc": "1.10.16",
-        "@swc/core-win32-x64-msvc": "1.10.16"
+        "@swc/core-darwin-arm64": "1.11.1",
+        "@swc/core-darwin-x64": "1.11.1",
+        "@swc/core-linux-arm-gnueabihf": "1.11.1",
+        "@swc/core-linux-arm64-gnu": "1.11.1",
+        "@swc/core-linux-arm64-musl": "1.11.1",
+        "@swc/core-linux-x64-gnu": "1.11.1",
+        "@swc/core-linux-x64-musl": "1.11.1",
+        "@swc/core-win32-arm64-msvc": "1.11.1",
+        "@swc/core-win32-ia32-msvc": "1.11.1",
+        "@swc/core-win32-x64-msvc": "1.11.1"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -10194,9 +10595,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.16.tgz",
-      "integrity": "sha512-iikIxwqCQ4Bvz79vJ4ELh26efPf1u5D9TFdmXSJUBs7C3mmMHvk5zyWD9A9cTowXiW6WHs2gE58U1R9HOTTIcg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-bJbqZ51JghEZ8WaFetofkfkS3MWsS/V3vDvY+0r+SlLeocZwf8q8/GqcafnElHcU+zLV6yTi13fJwUce6ULiUQ==",
       "cpu": [
         "arm64"
       ],
@@ -10211,9 +10612,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.16.tgz",
-      "integrity": "sha512-R2Eb9aktWd62vPfW9H/c/OaQ0e94iURibBo4uzUUcgxNNmB4+wb6piKbHxGdr/5bEsT+vJ1lwZFSRzfb45E7DA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-9GGEoN0uxkLg3KocOVzMfe9c9/DxESXclsL/U2xVLa3pTFB5YnXhiCP5YBT/3Q7nSGLD+R2ALqkNlDoueUjvPw==",
       "cpu": [
         "x64"
       ],
@@ -10228,9 +10629,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.16.tgz",
-      "integrity": "sha512-mkqN3HBAMnuiSGZ/k2utScuH8rAPshvNj0T1LjBWon+X9DkMNHSA+aMLdWsy0yZKF1zjOPc4L3Uq2l2wzhUlzA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-Lt7l/l0nfSTUzsWcVY3dtOPl5RtgCJ+Ya8IG4Aa3l6c7kLc6Sx4JpylpEIY9yhGidDy/uQ8KUg5kqUPtUrXrvQ==",
       "cpu": [
         "arm"
       ],
@@ -10245,9 +10646,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.16.tgz",
-      "integrity": "sha512-PH/+q/L5nVZJ91CU07CL6Q9Whs6iR6nneMZMAgtVF9Ix8ST0cWVItdUhs6D38kFklCFhaOrpHhS01HlMJ72vWw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-oe826cfuGukctTSpDjk7RJRDEJihQMAzvO5tdWK0wcy+zvMPFyH5Fg6cW0X4ST3M7fcV91/1T/iuiiD2SVamYw==",
       "cpu": [
         "arm64"
       ],
@@ -10262,9 +10663,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.16.tgz",
-      "integrity": "sha512-1169+C9XbydKKc6Ec1XZxTGKtHjZHDIFn0r+Nqp/QSVwkORrOY1Vz2Hdu7tn/lWMg36ZkGePS+LnnyV67s/7yg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-ABb4pnYeQp/JBJS5Qd2apTwOzpzrTebQFUiFjk0WgTKIr9T6SL3tLXMjgvbSXIath+1HnbCKFUwDXNQhgGFFTg==",
       "cpu": [
         "arm64"
       ],
@@ -10279,9 +10680,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.16.tgz",
-      "integrity": "sha512-n2rV0XwkjoHn4MDJmpYp5RBrnyi94/6GsJVpbn6f+/eqSrZn3mh3dT7pdZc9zCN1Qp9eDHo+uI6e/wgvbL22uA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-E09TcHv40bV0mOHTKquZw0IOcQ+lzzpQjyOhCa7+GBpbS3eg5/35Gu7DfToN2bomz74LPKW/l7jZRG+ZNOYNHQ==",
       "cpu": [
         "x64"
       ],
@@ -10296,9 +10697,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.16.tgz",
-      "integrity": "sha512-EevCpwreBrkPrJjQVIbiM81lK42ukNNSlBmrSRxxbx2V9VGmOd5qxX0cJBn0TRRSLIPi62BuMS76F9iYjqsjgg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-cuW4r7GbvQt9uv+rGdYLHUjDvGjHmr1nYE7iFVk6r4i+byZuXBK6M7P1p+/dTzacshOc05I9n/eUV+Hfjp9a3A==",
       "cpu": [
         "x64"
       ],
@@ -10313,9 +10714,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.16.tgz",
-      "integrity": "sha512-BvE7RWAnKJeELVQWLok6env5I4GUVBTZSvaSN/VPgxnTjF+4PsTeQptYx0xCYhp5QCv68wWYsBnZKuPDS+SBsw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-H8Q78GwaKnCL4isHx8JRTRi6vUU6iMLbpegS2jzWWC1On7EePhkLx2eR8nEsaRIQB6rc3WqdIj74OgOpNoPi7g==",
       "cpu": [
         "arm64"
       ],
@@ -10330,9 +10731,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.16.tgz",
-      "integrity": "sha512-7Jf/7AeCgbLR/JsQgMJuacHIq4Jeie3knf6+mXxn8aCvRypsOTIEu0eh7j24SolOboxK1ijqJ86GyN1VA2Rebg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-Rx7cZ0OvqMb16fgmUSlPWQbH1+X355IDJhVQpUlpL+ezD/kkWmJix+4u2GVE/LHrfbdyZ4sjjIzSsCQxJV05Mw==",
       "cpu": [
         "ia32"
       ],
@@ -10347,9 +10748,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.16.tgz",
-      "integrity": "sha512-p0blVm0R8bjaTtmW+FoPmLxLSQdRNbqhuWcR/8g80OzMSkka9mk5/J3kn/5JRVWh+MaR9LHRHZc1Q1L8zan13g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-6bEEC/XU1lwYzUXY7BXj3nhe7iBF9+i9dVo+hbiVxXZMrD0LUd+7urOBM3NtVnDsUaR6Ge/g7aR+OfpgYscKOg==",
       "cpu": [
         "x64"
       ],
@@ -10381,9 +10782,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.18.tgz",
+      "integrity": "sha512-NZghLaQvF3eFdj2DUjGkpwaunbZYaRcxciHINnwA4n3FrLAI8hKFOBqs2wkcOiLQfWkIdfuG6gBkNFrkPNji5g==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10824,9 +11225,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -10981,17 +11382,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.0.tgz",
-      "integrity": "sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
+      "integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/type-utils": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/type-utils": "8.25.0",
+        "@typescript-eslint/utils": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -11011,16 +11412,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.0.tgz",
-      "integrity": "sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
+      "integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/typescript-estree": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -11036,13 +11437,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.0.tgz",
-      "integrity": "sha512-HZIX0UByphEtdVBKaQBgTDdn9z16l4aTUz8e8zPQnyxwHBtf5vtl1L+OhH+m1FGV9DrRmoDuYKqzVrvWDcDozw==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+      "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0"
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11053,13 +11454,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.0.tgz",
-      "integrity": "sha512-8fitJudrnY8aq0F1wMiPM1UUgiXQRJ5i8tFjq9kGfRajU+dbPyOuHbl0qRopLEidy0MwqgTHDt6CnSeXanNIwA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
+      "integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0",
+        "@typescript-eslint/typescript-estree": "8.25.0",
+        "@typescript-eslint/utils": "8.25.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -11076,9 +11477,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.0.tgz",
-      "integrity": "sha512-VacJCBTyje7HGAw7xp11q439A+zeGG0p0/p2zsZwpnMzjPB5WteaWqt4g2iysgGFafrqvyLWqq6ZPZAOCoefCw==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+      "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11089,13 +11490,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.0.tgz",
-      "integrity": "sha512-ITjYcP0+8kbsvT9bysygfIfb+hBj6koDsu37JZG7xrCiy3fPJyNmfVtaGsgTUSEuTzcvME5YI5uyL5LD1EV5ZQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+      "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -11130,15 +11531,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.0.tgz",
-      "integrity": "sha512-07rLuUBElvvEb1ICnafYWr4hk8/U7X9RDCOqd9JcAMtjh/9oRmcfN4yGzbPVirgMR0+HLVHehmu19CWeh7fsmQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+      "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/typescript-estree": "8.24.0"
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11153,12 +11554,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.0.tgz",
-      "integrity": "sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+      "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.24.0",
+        "@typescript-eslint/types": "8.25.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -11929,9 +12330,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
+      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -12886,9 +13287,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001699",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
-      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
+      "version": "1.0.30001701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -13808,30 +14209,30 @@
       }
     },
     "node_modules/cspell": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.17.3.tgz",
-      "integrity": "sha512-fBZg674Dir9y/FWMwm2JyixM/1eB2vnqHJjRxOgGS/ZiZ3QdQ3LkK02Aqvlni8ffWYDZnYnYY9rfWmql9bb42w==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-8.17.5.tgz",
+      "integrity": "sha512-l3Cfp87d7Yrodem675irdxV6+7+OsdR+jNwYHe33Dgnd6ePEfooYrvmfGdXF9rlQrNLUQp/HqYgHJzSq19UEsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "8.17.3",
-        "@cspell/cspell-pipe": "8.17.3",
-        "@cspell/cspell-types": "8.17.3",
-        "@cspell/dynamic-import": "8.17.3",
-        "@cspell/url": "8.17.3",
+        "@cspell/cspell-json-reporter": "8.17.5",
+        "@cspell/cspell-pipe": "8.17.5",
+        "@cspell/cspell-types": "8.17.5",
+        "@cspell/dynamic-import": "8.17.5",
+        "@cspell/url": "8.17.5",
         "chalk": "^5.4.1",
         "chalk-template": "^1.1.0",
         "commander": "^13.1.0",
-        "cspell-dictionary": "8.17.3",
-        "cspell-gitignore": "8.17.3",
-        "cspell-glob": "8.17.3",
-        "cspell-io": "8.17.3",
-        "cspell-lib": "8.17.3",
+        "cspell-dictionary": "8.17.5",
+        "cspell-gitignore": "8.17.5",
+        "cspell-glob": "8.17.5",
+        "cspell-io": "8.17.5",
+        "cspell-lib": "8.17.5",
         "fast-json-stable-stringify": "^2.1.0",
         "file-entry-cache": "^9.1.0",
         "get-stdin": "^9.0.0",
-        "semver": "^7.6.3",
-        "tinyglobby": "^0.2.10"
+        "semver": "^7.7.1",
+        "tinyglobby": "^0.2.12"
       },
       "bin": {
         "cspell": "bin.mjs",
@@ -13845,13 +14246,13 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.17.3.tgz",
-      "integrity": "sha512-+N32Q6xck3D2RqZIFwq8s0TnzHYMpyh4bgNtYqW5DIP3TLDiA4/MJGjwmLKAg/s9dkre6n8/++vVli3MZAOhIg==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.17.5.tgz",
+      "integrity": "sha512-XDc+UJO5RZ9S9e2Ajz332XjT7dv6Og2UqCiSnAlvHt7t/MacLHSPARZFIivheObNkWZ7E1iWI681RxKoH4o40w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "8.17.3",
+        "@cspell/cspell-types": "8.17.5",
         "comment-json": "^4.2.5",
         "yaml": "^2.7.0"
       },
@@ -13860,15 +14261,15 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.17.3.tgz",
-      "integrity": "sha512-89I/lpQKdkX17RCFrUIJnc70Rjfpup/o+ynHZen0hUxGTfLsEJPrK6H2oGvic3Yrv5q8IOtwM1p8vqPqBkBheA==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.17.5.tgz",
+      "integrity": "sha512-O/Uuhv1RuDu+5WYQml0surudweaTvr+2YJSmPSdlihByUSiogCbpGqwrRow7wQv/C5p1W1FlFjotvUfoR0fxHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.17.3",
-        "@cspell/cspell-types": "8.17.3",
-        "cspell-trie-lib": "8.17.3",
+        "@cspell/cspell-pipe": "8.17.5",
+        "@cspell/cspell-types": "8.17.5",
+        "cspell-trie-lib": "8.17.5",
         "fast-equals": "^5.2.2"
       },
       "engines": {
@@ -13876,15 +14277,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.17.3.tgz",
-      "integrity": "sha512-rQamjb8R+Nwib/Bpcgf+xv5IdsOHgbP+fe4hCgv0jjgUPkeOR2c4dGwc0WS+2UkJbc+wQohpzBGDLRYGSB/hQw==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-8.17.5.tgz",
+      "integrity": "sha512-I27fgOUZzH14jeIYo65LooB60fZ42f6OJL1lOR9Mk6IrIlDyUtzherGR+xx5KshK2katYkX42Qu4zsVYM6VFPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.17.3",
-        "cspell-glob": "8.17.3",
-        "cspell-io": "8.17.3",
+        "@cspell/url": "8.17.5",
+        "cspell-glob": "8.17.5",
+        "cspell-io": "8.17.5",
         "find-up-simple": "^1.0.0"
       },
       "bin": {
@@ -13895,13 +14296,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.17.3.tgz",
-      "integrity": "sha512-0ov9A0E6OuOO7KOxlGCxJ09LR/ubZ6xcGwWc5bu+jp/8onUowQfe+9vZdznj/o8/vcf5JkDzyhRSBsdhWKqoAg==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.17.5.tgz",
+      "integrity": "sha512-OXquou7UykInlGV5et5lNKYYrW0dwa28aEF995x1ocANND7o0bbHmFlbgyci/Lp4uFQai8sifmfFJbuIg2IC/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "8.17.3",
+        "@cspell/url": "8.17.5",
         "micromatch": "^4.0.8"
       },
       "engines": {
@@ -13909,14 +14310,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.17.3.tgz",
-      "integrity": "sha512-wfjkkvHthnKJtEaTgx3cPUPquGRXfgXSCwvMJaDyUi36KBlopXX38PejBTdmuqrvp7bINLSuHErml9wAfL5Fxw==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.17.5.tgz",
+      "integrity": "sha512-st2n+FVw25MvMbsGb3TeJNRr6Oih4g14rjOd/UJN0qn+ceH360SAShUFqSd4kHHu2ADazI/TESFU6FRtMTPNOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.17.3",
-        "@cspell/cspell-types": "8.17.3"
+        "@cspell/cspell-pipe": "8.17.5",
+        "@cspell/cspell-types": "8.17.5"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -13926,49 +14327,49 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.17.3.tgz",
-      "integrity": "sha512-NwEVb3Kr8loV1C8Stz9QSMgUrBkxqf2s7A9H2/RBnfvQBt9CWZS6NgoNxTPwHj3h1sUNl9reDkMQQzkKtgWGBQ==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.17.5.tgz",
+      "integrity": "sha512-oevM/8l0s6nc1NCYPqNFumrW50QSHoa6wqUT8cWs09gtZdE2AWG0U6bIE8ZEVz6e6FxS+6IenGKTdUUwP0+3fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.17.3",
-        "@cspell/url": "8.17.3"
+        "@cspell/cspell-service-bus": "8.17.5",
+        "@cspell/url": "8.17.5"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.17.3.tgz",
-      "integrity": "sha512-KpwYIj8HwFyTzCCQcyezlmomvyNfPwZQmqTh4V126sFvf9HLoMdfyq8KYDZmZ//4HzwrF/ufJOF3CpuVUiJHfA==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.17.5.tgz",
+      "integrity": "sha512-S3KuOrcST1d2BYmTXA+hnbRdho5n3w5GUvEaCx3QZQBwAPfLpAwJbe2yig1TxBpyEJ5LqP02i/mDg1pUCOP0hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.17.3",
-        "@cspell/cspell-pipe": "8.17.3",
-        "@cspell/cspell-resolver": "8.17.3",
-        "@cspell/cspell-types": "8.17.3",
-        "@cspell/dynamic-import": "8.17.3",
-        "@cspell/filetypes": "8.17.3",
-        "@cspell/strong-weak-map": "8.17.3",
-        "@cspell/url": "8.17.3",
+        "@cspell/cspell-bundled-dicts": "8.17.5",
+        "@cspell/cspell-pipe": "8.17.5",
+        "@cspell/cspell-resolver": "8.17.5",
+        "@cspell/cspell-types": "8.17.5",
+        "@cspell/dynamic-import": "8.17.5",
+        "@cspell/filetypes": "8.17.5",
+        "@cspell/strong-weak-map": "8.17.5",
+        "@cspell/url": "8.17.5",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.5",
-        "cspell-config-lib": "8.17.3",
-        "cspell-dictionary": "8.17.3",
-        "cspell-glob": "8.17.3",
-        "cspell-grammar": "8.17.3",
-        "cspell-io": "8.17.3",
-        "cspell-trie-lib": "8.17.3",
+        "cspell-config-lib": "8.17.5",
+        "cspell-dictionary": "8.17.5",
+        "cspell-glob": "8.17.5",
+        "cspell-grammar": "8.17.5",
+        "cspell-io": "8.17.5",
+        "cspell-trie-lib": "8.17.5",
         "env-paths": "^3.0.0",
         "fast-equals": "^5.2.2",
         "gensequence": "^7.0.0",
-        "import-fresh": "^3.3.0",
+        "import-fresh": "^3.3.1",
         "resolve-from": "^5.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
-        "vscode-uri": "^3.0.8",
+        "vscode-uri": "^3.1.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
@@ -13989,18 +14390,31 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.17.3",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.17.3.tgz",
-      "integrity": "sha512-6LE5BeT2Rwv0bkQckpxX0K1fnFCWfeJ8zVPFtYOaix0trtqj0VNuwWzYDnxyW+OwMioCH29yRAMODa+JDFfUrA==",
+      "version": "8.17.5",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.17.5.tgz",
+      "integrity": "sha512-9hjI3nRQxtGEua6CgnLbK3sGHLx9dXR/BHwI/csRL4dN5GGRkE5X3CCoy1RJVL7iGFLIzi43+L10xeFRmWniKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "8.17.3",
-        "@cspell/cspell-types": "8.17.3",
+        "@cspell/cspell-pipe": "8.17.5",
+        "@cspell/cspell-types": "8.17.5",
         "gensequence": "^7.0.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cspell/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -15049,9 +15463,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.101",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.101.tgz",
-      "integrity": "sha512-L0ISiQrP/56Acgu4/i/kfPwWSgrzYZUnQrC0+QPFuhqlLP1Ir7qzPPDVS9BcKIyWTRU8+o6CC8dKw38tSWhYIA==",
+      "version": "1.5.105",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.105.tgz",
+      "integrity": "sha512-ccp7LocdXx3yBhwiG0qTQ7XFrK48Ua2pxIxBdJO8cbddp/MvbBtPFzvnTchtyHQTsgqqczO8cdmAIbpMa0u2+g==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -15373,21 +15787,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.11.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.20.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -16131,9 +16545,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -16383,9 +16797,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -16409,12 +16823,12 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -16856,17 +17270,17 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -19338,9 +19752,9 @@
       }
     },
     "node_modules/jest-preset-angular": {
-      "version": "14.5.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.5.1.tgz",
-      "integrity": "sha512-HLYYMwNcv3mFrKbOPJwR29tKqVg+yWxez8ilCIsEj1HRYZ/OVsBy5+dcMok+VqL5nmeukTsGnEfGWt+SsQqtkA==",
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.5.3.tgz",
+      "integrity": "sha512-ouvj0WMo5zcyD+DY1zaOCSROwsIsPnvyQmo6x24zKHg/jBfkUuE3AE+B3VXNZvgCTQAjnFwn92D4Lkj6yuQQ9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20448,9 +20862,9 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.9.1.tgz",
-      "integrity": "sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.10.0.tgz",
+      "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -22681,9 +23095,9 @@
       }
     },
     "node_modules/npm-package-json-lint/node_modules/type-fest": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
-      "integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -24332,9 +24746,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -24399,13 +24813,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
@@ -24895,9 +25302,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.34.1.tgz",
-      "integrity": "sha512-6kSc32kT0rbwxD6QL1CYe8IqdzN/J/ILMrNK+HMQCKH3insCDRY/3ITb0vcBss0a3t72fzh2YSzj8ko1HgwT3g==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
+      "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -25238,9 +25645,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -25298,9 +25705,9 @@
       }
     },
     "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.3.tgz",
-      "integrity": "sha512-oSwM7q8PTHQWuZAlp995iPpPJ4Vkl7qT0ZRD+9duL9j2oBy6KcTfyxc8mEuHJYC+z/kbps80aJLkaNzTOrf/kw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -25444,9 +25851,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -25621,18 +26028,18 @@
       }
     },
     "node_modules/secretlint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-9.0.0.tgz",
-      "integrity": "sha512-qk3yrdaslZ5J2u556Bj78xQysimQ3WHktrhk51t9zBJDm7yMpxltYUgG/07vJ3leqKZ5csLnZdSDWhzhiseNag==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-9.2.0.tgz",
+      "integrity": "sha512-LLrwZ6fBaqqXJCQ708SHzlS4GaHmhYYAuqqAiRhvqrWhiUfSPHOCY7y/oxqC/BJDhX3kT+BwbCev/ygjuQ+XSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/config-creator": "^9.0.0",
-        "@secretlint/formatter": "^9.0.0",
-        "@secretlint/node": "^9.0.0",
-        "@secretlint/profiler": "^9.0.0",
-        "debug": "^4.3.7",
-        "globby": "^14.0.2",
+        "@secretlint/config-creator": "^9.2.0",
+        "@secretlint/formatter": "^9.2.0",
+        "@secretlint/node": "^9.2.0",
+        "@secretlint/profiler": "^9.2.0",
+        "debug": "^4.4.0",
+        "globby": "^14.1.0",
         "meow": "^12.1.1",
         "read-pkg": "^8.1.0"
       },
@@ -27158,35 +27565,38 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
-      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.2",
+        "fdir": "^6.4.3",
         "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.77",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.77.tgz",
-      "integrity": "sha512-lBpoWgy+kYmuXWQ83+R7LlJCnsd9YW8DGpZSHhrMl4b8Ly/1vzOie3OdtmUJDkKxcgRGOehDu5btKkty+JEe+g==",
+      "version": "6.1.78",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.78.tgz",
+      "integrity": "sha512-fSgYrW0ITH0SR/CqKMXIruYIPpNu5aDgUp22UhYoSrnUQwc7SBqifEBFNce7AAcygUPBo6a/gbtcguWdmko4RQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.77"
+        "tldts-core": "^6.1.78"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.77",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.77.tgz",
-      "integrity": "sha512-bCaqm24FPk8OgBkM0u/SrEWJgHnhBWYqeBo6yUmcZJDCHt/IfyWBb+14CXdGi4RInMv4v7eUAin15W0DoA+Ytg==",
+      "version": "6.1.78",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.78.tgz",
+      "integrity": "sha512-jS0svNsB99jR6AJBmfmEWuKIgz91Haya91Z43PATaeHJ24BkMoNRb/jlaD37VYjb0mYf6gRL/HOnvS1zEnYBiw==",
       "dev": true,
       "license": "MIT"
     },
@@ -27309,9 +27719,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
-      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+      "version": "29.2.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
+      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27322,7 +27732,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.6.3",
+        "semver": "^7.7.1",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -27355,6 +27765,19 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ts-loader": {
@@ -27667,15 +28090,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.24.0.tgz",
-      "integrity": "sha512-/lmv4366en/qbB32Vz5+kCNZEMf6xYHwh1z48suBwZvAtnXKbP+YhGe8OLE2BqC67LMqKkCNLtjejdwsdW6uOQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
+      "integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.24.0",
-        "@typescript-eslint/parser": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0"
+        "@typescript-eslint/eslint-plugin": "8.25.0",
+        "@typescript-eslint/parser": "8.25.0",
+        "@typescript-eslint/utils": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -27836,9 +28259,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",
@@ -27996,14 +28419,14 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
+      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "esbuild": "^0.24.2",
-        "postcss": "^8.5.1",
+        "esbuild": "^0.25.0",
+        "postcss": "^8.5.3",
         "rollup": "^4.30.1"
       },
       "bin": {
@@ -28067,10 +28490,476 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
+      }
+    },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
This PR adds a check for formatting rules into the pipeline. Although, formatting rules are applied during pre-commit hook already, the check is added here, so that also formatting is part of the CI/CD checks.

Additionally, dependencies are updated/refreshed again.